### PR TITLE
add privilege functions / minetest.mkdir / minetest.get_content_id

### DIFF
--- a/common/fs.lua
+++ b/common/fs.lua
@@ -1,0 +1,5 @@
+
+minetest.mkdir = function()
+	-- no-op
+	-- TODO: create directory and implement io.* functions
+end

--- a/core.lua
+++ b/core.lua
@@ -56,9 +56,11 @@ mineunit("game/constants")
 mineunit("game/item")
 mineunit("game/misc")
 mineunit("game/register")
+mineunit("game/privileges")
 mineunit("common/misc_helpers")
 mineunit("common/vector")
 mineunit("common/serialize")
+mineunit("common/fs")
 
 mineunit("metadata")
 mineunit("itemstack")
@@ -97,6 +99,22 @@ _G.minetest.get_node = function(pos)
 end
 _G.minetest.get_node_timer = {}
 setmetatable(_G.minetest.get_node_timer, noop_object)
+
+local max_content_id = 0
+local content_ids = {}
+_G.minetest.get_content_id = function(name)
+	-- check if the node exists
+	if not minetest.registered_nodes[name] then
+		error("not registered: " .. name)
+	end
+
+	-- create and increment
+	if not content_ids[name] then
+		content_ids[name] = max_content_id
+		max_content_id = max_content_id + 1
+	end
+	return content_ids[name]
+end
 
 --
 -- Minetest default noop table

--- a/core.lua
+++ b/core.lua
@@ -104,9 +104,7 @@ local max_content_id = 0
 local content_ids = {}
 _G.minetest.get_content_id = function(name)
 	-- check if the node exists
-	if not minetest.registered_nodes[name] then
-		error("not registered: " .. name)
-	end
+	assert(minetest.registered_nodes[name], "node " .. name .. " is not registered")
 
 	-- create and increment
 	if not content_ids[name] then

--- a/game/privileges.lua
+++ b/game/privileges.lua
@@ -1,0 +1,101 @@
+-- Minetest: builtin/privileges.lua
+
+--
+-- Privileges
+--
+
+core.registered_privileges = {}
+
+function core.register_privilege(name, param)
+	local function fill_defaults(def)
+		if def.give_to_singleplayer == nil then
+			def.give_to_singleplayer = true
+		end
+		if def.give_to_admin == nil then
+			def.give_to_admin = def.give_to_singleplayer
+		end
+		if def.description == nil then
+			def.description = "(no description)"
+		end
+	end
+	local def
+	if type(param) == "table" then
+		def = param
+	else
+		def = {description = param}
+	end
+	fill_defaults(def)
+	core.registered_privileges[name] = def
+end
+
+core.register_privilege("interact", "Can interact with things and modify the world")
+core.register_privilege("shout", "Can speak in chat")
+core.register_privilege("basic_privs", "Can modify 'shout' and 'interact' privileges")
+core.register_privilege("privs", "Can modify privileges")
+
+core.register_privilege("teleport", {
+	description = "Can teleport self",
+	give_to_singleplayer = false,
+})
+core.register_privilege("bring", {
+	description = "Can teleport other players",
+	give_to_singleplayer = false,
+})
+core.register_privilege("settime", {
+	description = "Can set the time of day using /time",
+	give_to_singleplayer = false,
+})
+core.register_privilege("server", {
+	description = "Can do server maintenance stuff",
+	give_to_singleplayer = false,
+	give_to_admin = true,
+})
+core.register_privilege("protection_bypass", {
+	description = "Can bypass node protection in the world",
+	give_to_singleplayer = false,
+})
+core.register_privilege("ban", {
+	description = "Can ban and unban players",
+	give_to_singleplayer = false,
+	give_to_admin = true,
+})
+core.register_privilege("kick", {
+	description = "Can kick players",
+	give_to_singleplayer = false,
+	give_to_admin = true,
+})
+core.register_privilege("give", {
+	description = "Can use /give and /giveme",
+	give_to_singleplayer = false,
+})
+core.register_privilege("password", {
+	description = "Can use /setpassword and /clearpassword",
+	give_to_singleplayer = false,
+	give_to_admin = true,
+})
+core.register_privilege("fly", {
+	description = "Can use fly mode",
+	give_to_singleplayer = false,
+})
+core.register_privilege("fast", {
+	description = "Can use fast mode",
+	give_to_singleplayer = false,
+})
+core.register_privilege("noclip", {
+	description = "Can fly through solid nodes using noclip mode",
+	give_to_singleplayer = false,
+})
+core.register_privilege("rollback", {
+	description = "Can use the rollback functionality",
+	give_to_singleplayer = false,
+})
+core.register_privilege("debug", {
+	description = "Allows enabling various debug options that may affect gameplay",
+	give_to_singleplayer = false,
+	give_to_admin = true,
+})
+
+core.register_can_bypass_userlimit(function(name, ip)
+	local privs = core.get_player_privs(name)
+	return privs["server"] or privs["ban"] or privs["privs"] or privs["password"]
+end)


### PR DESCRIPTION
this PR adds:
* `minetest.mkdir` stub, does not do anything
* `minetest.get_content_id` returns a cached, incremented id for each nodename and checks if they exist
* the whole `builtin/privileges.lua` galore, not sure if that needs to be specified in a license file somewhere :thinking: 

**EDIT**: when/how does the rock-package get updated and when is that stable/non-dev?