### PR TITLE
Metadata and world / core.set_node updates

### DIFF
--- a/globals.lua
+++ b/globals.lua
@@ -130,6 +130,14 @@ function core.get_craft_result(t)
 		assert(#t.items > 0, "core.get_craft_result: t.items is empty")
 		for k, v in ipairs(t.items) do
 			assert.is_ItemStack(v, "core.get_craft_result: t.items["..k.."] ItemStack expected")
+			--assert(#v:get_name() > 0, "core.get_craft_result: t.items["..k.."] invalid ItemStack")
+			if #v:get_name() == 0 then
+				return
+			end
+		end
+	else
+		if #t.items:get_name() == 0 then
+			return
 		end
 	end
 	local items = is_ItemStack(t.items) and {t.items} or t.items
@@ -154,7 +162,7 @@ function core.get_craft_result(t)
 				}
 		end
 	end
-	error("FAILED")
+	error("core.get_craft_result failed, input was: "..dump(t))
 	return {
 		item = ItemStack(),
 		time = 0,

--- a/itemstack.lua
+++ b/itemstack.lua
@@ -79,7 +79,13 @@ function ItemStack:to_string()
 end
 --* `to_table()`: returns the stack in Lua table form.
 function ItemStack:to_table()
-	error("NOT IMPLEMENTED")
+	-- FIXME: Format is probably wrong, missing something or has too much something. Check actual spec and fix.
+	return {
+		name = self:get_name(),
+		count = self:get_count(),
+		wear = self:get_wear(),
+		meta = self:get_meta():to_table(),
+	}
 end
 --* `get_stack_max()`: returns the maximum size of the stack (depends on the item).
 function ItemStack:get_stack_max()

--- a/metadata.lua
+++ b/metadata.lua
@@ -151,7 +151,7 @@ function InvRef:set_stack(listname, i, stack)
 end
 -- * `get_list(listname)`: return full list
 function InvRef:get_list(listname)
-	mineunit:warning("InvRef:get_list returning list "..listname.." as reference, this can lead to unxpected results")
+	mineunit:debug("InvRef:get_list returning list "..listname.." as reference, this can lead to unxpected results")
 	return self._lists[listname]
 end
 -- * `set_list(listname, list)`: set full list (size will not change)

--- a/metadata.lua
+++ b/metadata.lua
@@ -242,7 +242,14 @@ function MetaDataRef:set_int(key, value) self:set_string(key, math.floor(value))
 function MetaDataRef:get_int(key) return math.floor(tonumber(self._data[key]) or 0) end
 function MetaDataRef:set_float(key, value) self:set_string(key, value) end
 function MetaDataRef:get_float(key) return tonumber(self._data[key]) or 0 end
-function MetaDataRef:to_table() error("NOT IMPLEMENTED") end
+function MetaDataRef:to_table()
+	-- FIXME: This is wrong almost sure, check actual engine spec and fix it to return correct format.
+	local result = {}
+	for key, value in pairs(self._data) do
+		result[key] = tostring(value)
+	end
+	return result
+end
 function MetaDataRef:from_table(t) error("NOT IMPLEMENTED") end
 function MetaDataRef:equals(other) error("NOT IMPLEMENTED") end
 

--- a/world.lua
+++ b/world.lua
@@ -9,6 +9,14 @@ local function call(fn, ...)
 	end
 end
 
+local function create_node(node, defaults)
+	node = type(node) == "table" and node or { name = node }
+	return {
+		name = node.name and node.name or (defaults and defaults.name),
+		param2 = node.param2 and node.param2 or (defaults and defaults.param2 or 0),
+	}
+end
+
 -- FIXME: Node metadata should be integrated with world layout to handle set_node and its friends
 local worldmeta = {}
 function _G.core.get_meta(pos)
@@ -37,7 +45,7 @@ end
 
 -- set_node sets world node without place/dig callbacks
 function world.set_node(pos, node)
-	node = type(node) == "table" and node or { name = node, param2 = 0 }
+	node = create_node(node)
 	assert(type(node.name) == "string", "Invalid node name, expected string but got " .. tostring(node.name))
 	local hash = minetest.hash_node_position(pos)
 	local nodedef = core.registered_nodes[node.name]
@@ -59,8 +67,7 @@ end
 -- swap_node sets world node without any callbacks
 function world.swap_node(pos, node)
 	local hash = minetest.hash_node_position(pos)
-	node = type(node) == "table" and node or { name = node }
-	node.param2 = world.nodes[hash] and world.nodes[hash].param2 or 0
+	node = create_node(node, world.nodes[hash])
 	assert(type(node.name) == "string", "Invalid node name, expected string but got " .. tostring(node.name))
 	world.nodes[hash] = node
 end
@@ -69,6 +76,7 @@ end
 -- minetest.item_place_node / minetest.place_node.
 -- If return true no item is taken from itemstack.
 function world.place_node(pos, node, placer, itemstack, pointed_thing)
+	node = create_node(node)
 	world.set_node(pos, node)
 	local nodedef = core.registered_nodes[node.name]
 	assert(nodedef, "Invalid nodedef for " .. tostring(node.name))


### PR DESCRIPTION
`core.get_craft_result` returns `nil` when input is empty, also gives bit more info when it falls through toward complete failure.

Implemented (possibly wrong...) `to_table` methods for `ItemStack` and `MetaDataRef`.

Fixed few problems with `world.set_node` and its friends (ensure that supplied `node` always has correct fields).

Also reduced `InvRef:get_list(...)` spamming, so far no problems with it. Did not remove message because I'm still not sure if actual minetest engine returns lists as references.