### PR TITLE
Player API and authentication API

### DIFF
--- a/auth.lua
+++ b/auth.lua
@@ -1,0 +1,68 @@
+mineunit("player")
+
+-- AuthEntry class
+
+local last_unique_id = -1
+local function unique_id()
+	last_unique_id = last_unique_id + 1
+	return last_unique_id
+end
+
+local AuthEntry = {}
+
+mineunit.export_object(AuthEntry, {
+	name = "AuthEntry",
+	typename = "table",
+	constructor = function(self, name)
+		assert(type(name) == "string")
+		local obj = {}
+		local player = mineunit:get_players()[name]
+		assert.is_player(player)
+		obj.id = unique_id()
+		obj.name = name
+		obj.privileges = player._privs
+		obj.password = ""
+		obj.last_login = 0
+		setmetatable(obj, AuthEntry)
+		return obj
+	end,
+})
+
+-- Engine core.auth
+
+local auth = {}
+
+local entries = {}
+
+function auth.read(name)
+	if not entries[name] then
+		entries[name] = AuthEntry(name)
+	end
+	return entries[name]
+end
+
+function auth.save(entry)
+	local player = mineunit:get_players()[entry.name]
+	assert.is_Player(player)
+	player._privs = entry.privileges
+end
+
+function auth.create()
+	mineunit:info("auth.create() called")
+end
+
+function auth.delete()
+	mineunit:info("auth.delete() called")
+end
+
+function auth.list_names()
+	mineunit:info("auth.list_names() called")
+end
+
+function auth.reload()
+	mineunit:info("auth.reload() called")
+end
+
+_G.core.auth = auth
+
+mineunit("game/auth")

--- a/core.lua
+++ b/core.lua
@@ -7,6 +7,9 @@ local noop_object = {
 
 _G.world = mineunit("world")
 
+_G.core.is_singleplayer = function() return true end
+_G.core.notify_authentication_modified = noop
+
 _G.core.set_node = world.set_node
 _G.core.swap_node = world.swap_node
 
@@ -60,6 +63,8 @@ mineunit("common/fs")
 mineunit("metadata")
 mineunit("itemstack")
 
+_G.core.register_node(":air", {buildable_to = true})
+
 local mod_storage
 _G.minetest.get_mod_storage = function()
 	if not mod_storage then
@@ -71,6 +76,7 @@ end
 _G.minetest.sound_play = noop
 _G.minetest.sound_stop = noop
 _G.minetest.sound_fade = noop
+_G.minetest.add_particlespawner = noop
 
 _G.minetest.registered_chatcommands = {}
 _G.minetest.register_chatcommand = noop

--- a/game/auth.lua
+++ b/game/auth.lua
@@ -1,0 +1,185 @@
+-- Minetest: builtin/auth.lua
+
+--
+-- Builtin authentication handler
+--
+
+-- Make the auth object private, deny access to mods
+local core_auth = core.auth
+core.auth = nil
+
+core.builtin_auth_handler = {
+	get_auth = function(name)
+		assert(type(name) == "string")
+		local auth_entry = core_auth.read(name)
+		-- If no such auth found, return nil
+		if not auth_entry then
+			return nil
+		end
+		-- Figure out what privileges the player should have.
+		-- Take a copy of the privilege table
+		local privileges = {}
+		for priv, _ in pairs(auth_entry.privileges) do
+			privileges[priv] = true
+		end
+		-- If singleplayer, give all privileges except those marked as give_to_singleplayer = false
+		if core.is_singleplayer() then
+			for priv, def in pairs(core.registered_privileges) do
+				if def.give_to_singleplayer then
+					privileges[priv] = true
+				end
+			end
+		-- For the admin, give everything
+		elseif name == core.settings:get("name") then
+			for priv, def in pairs(core.registered_privileges) do
+				if def.give_to_admin then
+					privileges[priv] = true
+				end
+			end
+		end
+		-- All done
+		return {
+			password = auth_entry.password,
+			privileges = privileges,
+			last_login = auth_entry.last_login,
+		}
+	end,
+	create_auth = function(name, password)
+		assert(type(name) == "string")
+		assert(type(password) == "string")
+		core.log('info', "Built-in authentication handler adding player '"..name.."'")
+		return core_auth.create({
+			name = name,
+			password = password,
+			privileges = core.string_to_privs(core.settings:get("default_privs")),
+			last_login = -1,  -- Defer login time calculation until record_login (called by on_joinplayer)
+		})
+	end,
+	delete_auth = function(name)
+		assert(type(name) == "string")
+		local auth_entry = core_auth.read(name)
+		if not auth_entry then
+			return false
+		end
+		core.log('info', "Built-in authentication handler deleting player '"..name.."'")
+		return core_auth.delete(name)
+	end,
+	set_password = function(name, password)
+		assert(type(name) == "string")
+		assert(type(password) == "string")
+		local auth_entry = core_auth.read(name)
+		if not auth_entry then
+			core.builtin_auth_handler.create_auth(name, password)
+		else
+			core.log('info', "Built-in authentication handler setting password of player '"..name.."'")
+			auth_entry.password = password
+			core_auth.save(auth_entry)
+		end
+		return true
+	end,
+	set_privileges = function(name, privileges)
+		assert(type(name) == "string")
+		assert(type(privileges) == "table")
+		local auth_entry = core_auth.read(name)
+		if not auth_entry then
+			auth_entry = core.builtin_auth_handler.create_auth(name,
+				core.get_password_hash(name,
+					core.settings:get("default_password")))
+		end
+
+		auth_entry.privileges = privileges
+
+		core_auth.save(auth_entry)
+
+		-- Run grant callbacks
+		for priv, _ in pairs(privileges) do
+			if not auth_entry.privileges[priv] then
+				core.run_priv_callbacks(name, priv, nil, "grant")
+			end
+		end
+
+		-- Run revoke callbacks
+		for priv, _ in pairs(auth_entry.privileges) do
+			if not privileges[priv] then
+				core.run_priv_callbacks(name, priv, nil, "revoke")
+			end
+		end
+		core.notify_authentication_modified(name)
+	end,
+	reload = function()
+		core_auth.reload()
+		return true
+	end,
+	record_login = function(name)
+		assert(type(name) == "string")
+		local auth_entry = core_auth.read(name)
+		assert(auth_entry)
+		auth_entry.last_login = os.time()
+		core_auth.save(auth_entry)
+	end,
+	iterate = function()
+		local names = {}
+		local nameslist = core_auth.list_names()
+		for k,v in pairs(nameslist) do
+			names[v] = true
+		end
+		return pairs(names)
+	end,
+}
+
+core.register_on_prejoinplayer(function(name, ip)
+	if core.registered_auth_handler ~= nil then
+		return -- Don't do anything if custom auth handler registered
+	end
+	local auth_entry = core_auth.read(name)
+	if auth_entry ~= nil then
+		return
+	end
+
+	local name_lower = name:lower()
+	for k in core.builtin_auth_handler.iterate() do
+		if k:lower() == name_lower then
+			return string.format("\nCannot create new player called '%s'. "..
+					"Another account called '%s' is already registered. "..
+					"Please check the spelling if it's your account "..
+					"or use a different nickname.", name, k)
+		end
+	end
+end)
+
+--
+-- Authentication API
+--
+
+function core.register_authentication_handler(handler)
+	if core.registered_auth_handler then
+		error("Add-on authentication handler already registered by "..core.registered_auth_handler_modname)
+	end
+	core.registered_auth_handler = handler
+	core.registered_auth_handler_modname = core.get_current_modname()
+	handler.mod_origin = core.registered_auth_handler_modname
+end
+
+function core.get_auth_handler()
+	return core.registered_auth_handler or core.builtin_auth_handler
+end
+
+local function auth_pass(name)
+	return function(...)
+		local auth_handler = core.get_auth_handler()
+		if auth_handler[name] then
+			return auth_handler[name](...)
+		end
+		return false
+	end
+end
+
+core.set_player_password = auth_pass("set_password")
+core.set_player_privs    = auth_pass("set_privileges")
+core.remove_player_auth  = auth_pass("delete_auth")
+core.auth_reload         = auth_pass("reload")
+
+local record_login = auth_pass("record_login")
+core.register_on_joinplayer(function(player)
+	record_login(player:get_player_name())
+end)

--- a/server.lua
+++ b/server.lua
@@ -137,6 +137,12 @@ end
 
 function mineunit:execute_on_joinplayer(player, lastlogin)
 	assert.is_Player(player, "Invalid call to mineunit:execute_on_joinplayer")
+	if core.get_auth_handler then
+		local name = player:get_player_name()
+		local data = core.get_auth_handler().get_auth(name)
+		core.set_player_privs(name, data.privileges)
+		mineunit:debug("Auth privileges:", player:get_player_name(), dump(player._privs))
+	end
 	player._online = true
 	return core.run_callbacks(
 		core.registered_on_joinplayers,


### PR DESCRIPTION
### Generic Mineunit API
* Add authentication API.
* Add `is_singleplayer()` that always returns `true`.
* Always register `air` node.
* Add `mineunit:get_players` to return all registered players without looking at online status.

### Mineunit Player API
* `Player:do_set_wieldslot(inv_slot)` to set current wield item slot.
* `Player:do_place(pointed_thing_or_pos)` to place current wield item at location.

### Minetest Player API
* `Player:get_look_dir()`
* `Player:get_look_vertical()`
* `Player:get_look_horizontal()`
* `Player:set_look_vertical(radians)`
* `Player:set_look_horizontal(radians)`

Empty methods, available but without actual functionality:
* `Player:set_inventory_formspec(formspec)` no-op method
* `Player:get_inventory_formspec()` no-op method
* `Player:set_formspec_prepend(formspec)` no-op method
* `Player:get_formspec_prepend(formspec)` no-op method

Deprecated methods:
* `Player:get_player_velocity()` calls `DEPRECATED()`
* `Player:add_player_velocity(vel)` calls `DEPRECATED()`
* `Player:get_look_pitch()` calls `DEPRECATED()`
* `Player:get_look_yaw()` calls `DEPRECATED()`
* `Player:set_look_pitch(radians)` calls `DEPRECATED()`
* `Player:set_look_yaw(radians)` calls `DEPRECATED()`
* `Player:set_attribute(attribute, value)` calls `DEPRECATED()`
* `Player:get_attribute(attribute)` calls `DEPRECATED()`
