### PR TITLE
Layout areas, module check, global_exists

### DIFF
--- a/globals.lua
+++ b/globals.lua
@@ -49,6 +49,10 @@ DIR_DELIM = "/"
 local core = {}
 _G.core = core
 
+function core.global_exists(name)
+	return rawget(_G, name) ~= nil
+end
+
 function core.log(...) mineunit:info(...) end
 function core.request_http_api(...) end
 

--- a/init.lua
+++ b/init.lua
@@ -61,6 +61,10 @@ if mineunit_config then
 	end
 end
 
+function mineunit:has_module(name)
+	return _mineunits[name] and true
+end
+
 function mineunit:config(key)
 	if self._config[key] ~= nil then
 		return self._config[key]


### PR DESCRIPTION
* Allow using `{pos1, pos2}` instead of single position with `world.layout` to fill area with selected node.
* Added `core.global_exists`
* Fixed `world.set_node` callbacks: `on_destruct`, `after_destruct`