### PR TITLE
Added get_name_from_content_id

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -140,7 +140,6 @@ _G.minetest.get_content_id = function(name)
 
 	-- create and increment
 	if not content_name2id[name] then
-		-- TODO: Verify that content id is 0 based instead of 1
 		content_name2id[name] = #content_id2name
 		table.insert(content_id2name, name)
 	end
@@ -148,14 +147,7 @@ _G.minetest.get_content_id = function(name)
 end
 
 _G.minetest.get_name_from_content_id = function(cid)
-	if not content_id2name[cid+1] then
-		-- TODO: Should this be error instead of "fixing" it? Content id depends on
-		-- load order and should not be known before calling minetest.get_content_id.
-		for name,_ in pairs(minetest.registered_nodes) do
-			minetest.get_content_id(name)
-		end
-		assert(content_id2name[cid+1], "Unknown content id")
-	end
+	assert(content_id2name[cid+1], "Unknown content id")
 	return content_id2name[cid+1]
 end
 


### PR DESCRIPTION
### What added
Function `get_content_id` was added here: #13

### To be decided
As content ids get generated when you ask for one there should not be id available for name before using `minetest.get_content_id(name)`.
This makes `minetest.get_name_from_content_id(cid)` generate missing ids when called with unknown content id.

Should `minetest.get_name_from_content_id(cid)` fail immediately if called with unknown id?
Also is content id 0 based or 1 based, probably 0 based (also used in original commit) is correct?