### PR TITLE
Add primitive formspec testing feature

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -64,7 +64,6 @@ _G.minetest.add_particlespawner = noop
 _G.minetest.registered_chatcommands = {}
 _G.minetest.register_chatcommand = noop
 _G.minetest.chat_send_player = function(...) print(unpack({...})) end
-_G.minetest.register_on_player_receive_fields = noop
 _G.minetest.register_on_placenode = noop
 _G.minetest.register_on_dignode = noop
 _G.minetest.register_on_mods_loaded = function(func) mineunit:register_on_mods_loaded(func) end

--- a/player.lua
+++ b/player.lua
@@ -42,7 +42,6 @@ function mineunit.send_formspec_fields(playername, fields)
 	if fields == nil then
 		fields = player._formspec_fields
 	end
-	player._formspec_fields = {}
 	for _, f in ipairs(core.registered_on_player_receive_fields) do
 		if f(player, player._formname, fields) then
 			break
@@ -63,6 +62,21 @@ end
 
 function mineunit.set_formspec_field(playername, key, value)
 	return mineunit.set_formspec_fields(playername, {key = value})
+end
+
+function mineunit.clear_formspec_fields(playername)
+	assert.is_string(playername, "mineunit.clear_formspec_fields: playername: expected string, got "..type(playername))
+	assert.is_Player(players[playername], "mineunit.clear_formspec_fields: player not found: "..playername)
+	local player = players[playername]
+	player._formspec_fields = {}
+end
+
+mineunit.formspec_action = {}
+
+function mineunit.formspec_action.quit(playername)
+	mineunit.set_formspec_field(playername, "quit", "true")
+	mineunit.send_formspec_fields(playername)
+	mineunit.clear_formspec_fields(playername)
 end
 
 function _G.core.get_player_privs(name)

--- a/player.lua
+++ b/player.lua
@@ -38,7 +38,7 @@ function mineunit.send_formspec_fields(playername, fields)
 	assert.is_Player(players[playername], "mineunit.send_formspec_fields: player not found: "..playername)
 	local player = players[playername]
 	assert(player._formname, "mineunit.send_formspec_fields: no formspec open")
-	assert(fields ~= nil and type(fields) ~= "table", "mineunit.send_formspec_fields: fields: expected table or nil, got "..type(fields))
+	assert(fields == nil or type(fields) == "table", "mineunit.send_formspec_fields: fields: expected table or nil, got "..type(fields))
 	if fields == nil then
 		fields = player._formspec_fields
 	end

--- a/player.lua
+++ b/player.lua
@@ -13,14 +13,15 @@ end
 
 local function set_formspec(player, formname, formspec)
 	player._formname, player._formspec = formname, formspec
+	player._formspec_fields = {}
 end
 
 function _G.core.show_formspec(playername, formname, formspec)
-	assert.is_string(playername, "core.show_formspec: playername: expected string, got "..type(name))
-	assert.is_Player(players[name], "core.show_formspec: player not found: "..name)
+	assert.is_string(playername, "core.show_formspec: playername: expected string, got "..type(playername))
+	assert.is_Player(players[playername], "core.show_formspec: player not found: "..playername)
 	assert.is_string(formname, "core.show_formspec: formname: expected string, got "..type(formname))
 	assert.is_string(formspec, "core.show_formspec: formspec: expected string, got "..type(formspec))
-	local player = players[name]
+	local player = players[playername]
 	if formname == "" then
 		set_formspec(player)
 	elseif formspec == "" then
@@ -30,6 +31,38 @@ function _G.core.show_formspec(playername, formname, formspec)
 	else
 		set_formspec(player, formname, formspec)
 	end
+end
+
+function mineunit.send_formspec_fields(playername, fields)
+	assert.is_string(playername, "mineunit.send_formspec_fields: playername: expected string, got "..type(playername))
+	assert.is_Player(players[playername], "mineunit.send_formspec_fields: player not found: "..playername)
+	local player = players[playername]
+	assert(player._formname, "mineunit.send_formspec_fields: no formspec open")
+	assert(fields ~= nil and type(fields) ~= "table", "mineunit.send_formspec_fields: fields: expected table or nil, got "..type(fields))
+	if fields == nil then
+		fields = player._formspec_fields
+	end
+	player._formspec_fields = {}
+	for _, f in ipairs(core.registered_on_player_receive_fields) do
+		if f(player, player._formname, fields) then
+			break
+		end
+	end
+end
+
+function mineunit.set_formspec_fields(playername, fields)
+	assert.is_string(playername, "mineunit.set_formspec_fields: playername: expected string, got "..type(playername))
+	assert.is_Player(players[playername], "mineunit.set_formspec_fields: player not found: "..playername)
+	local player = players[playername]
+	assert(player._formname, "mineunit.set_formspec_fields: no formspec open")
+	local fsfields = player._formspec_fields
+	for k, v in pairs(fields) do
+		fsfields[k] = v
+	end
+end
+
+function mineunit.set_formspec_field(playername, key, value)
+	return mineunit.set_formspec_fields(playername, {key = value})
 end
 
 function _G.core.get_player_privs(name)

--- a/player.lua
+++ b/player.lua
@@ -5,8 +5,8 @@ function mineunit:get_players()
 end
 
 function mineunit.get_player_formspec(playername)
-	assert.is_string(playername, "mineunit.show_formspec: playername: expected string, got "..type(playername))
-	assert.is_Player(players[playername], "core.show_formspec: player not found: "..playername)
+	assert.is_string(playername, "mineunit.get_player_formspec: playername: expected string, got "..type(playername))
+	assert.is_Player(players[playername], "core.get_player_formspec: player not found: "..playername)
 	local player = players[playername]
 	return player._formname, player._formspec
 end

--- a/player.lua
+++ b/player.lua
@@ -4,7 +4,33 @@ function mineunit:get_players()
 	return players
 end
 
-function _G.core.show_formspec(...) mineunit:info("core.show_formspec", ...) end
+function mineunit.get_player_formspec(playername)
+	assert.is_string(playername, "mineunit.show_formspec: playername: expected string, got "..type(playername))
+	assert.is_Player(players[playername], "core.show_formspec: player not found: "..playername)
+	local player = players[playername]
+	return player._formname, player._formspec
+end
+
+local function set_formspec(player, formname, formspec)
+	player._formname, player._formspec = formname, formspec
+end
+
+function _G.core.show_formspec(playername, formname, formspec)
+	assert.is_string(playername, "core.show_formspec: playername: expected string, got "..type(name))
+	assert.is_Player(players[name], "core.show_formspec: player not found: "..name)
+	assert.is_string(formname, "core.show_formspec: formname: expected string, got "..type(formname))
+	assert.is_string(formspec, "core.show_formspec: formspec: expected string, got "..type(formspec))
+	local player = players[name]
+	if formname == "" then
+		set_formspec(player)
+	elseif formspec == "" then
+		if player._formname == formname then
+			set_formspec(player)
+		end
+	else
+		set_formspec(player, formname, formspec)
+	end
+end
 
 function _G.core.get_player_privs(name)
 	assert.is_string(name, "core.get_player_privs: name: expected string, got "..type(name))
@@ -530,10 +556,10 @@ end
 function Player:set_attribute(attribute, value) DEPRECATED() end
 function Player:get_attribute(attribute) DEPRECATED() end
 
-function Player:set_inventory_formspec(formspec) end
-function Player:get_inventory_formspec() return "" end
-function Player:set_formspec_prepend(formspec) end
-function Player:get_formspec_prepend(formspec) return "" end
+function Player:set_inventory_formspec(formspec) self._inventory_formspec = formspec end
+function Player:get_inventory_formspec() return self._inventory_formspec end
+function Player:set_formspec_prepend(formspec) self._formspec_prepend = formspec end
+function Player:get_formspec_prepend(formspec) return self._formspec_prepend end
 
 function Player:hud_get_flags() return self._hud_flags end
 function Player:set_hud_flags(new_flags)

--- a/spec/player_spec.lua
+++ b/spec/player_spec.lua
@@ -493,4 +493,41 @@ describe("Mineunit Player", function()
 
 	end)
 
+	describe("Formspec system", function()
+		local player = Player("p9", {})
+		it("should show formspecs to the player", function()
+			core.show_formspec("p9", "fs1", "foo")
+			assert.same({"fs1", "foo"}, {mineunit.get_player_formspec("p9")})
+		end)
+		it("should not hide formspecs when the form name does not match", function()
+			core.close_formspec("p9", "fs2")
+			assert.same({"fs1", "foo"}, {mineunit.get_player_formspec("p9")})
+		end)
+		it("should close formspecs when the form name matches", function()
+			core.close_formspec("p9", "fs1")
+			assert.same({}, {mineunit.get_player_formspec("p9")})
+		end)
+		it("should close formspecs when the empty form name is passed", function()
+			core.show_formspec("p9", "fs1", "foo")
+			core.close_formspec("p9", "")
+			assert.same({}, {mineunit.get_player_formspec("p9")})
+		end)
+		it("should call callbacks correctly", function()
+			local count = 0
+			local realfields = { quit = "true" }
+			core.register_on_player_receive_fields(function(playername, formname, fields)
+				if formname == "fs1" then
+					count = 10
+				end
+			end)
+			core.register_on_player_receive_fields(function(playername, formname, fields)
+				assert.same(realfields, fields)
+				count = 1
+				return true
+			end)
+			core.show_formspec("p9", "fs1", "foo")
+			mineunit.send_formspec_fields("p9", realfields)
+			assert.equal(1, count)
+		end)
+	end)
 end)


### PR DESCRIPTION
This should at least partially address #53.

This PR is still WIP. Specifically, it does not provide an API to "interact" (*) with formspec elements, and formspecs need to be parsed in order to send the fields correctly.

(*) Whether the specific element is present is a different matter. IMO not checking this allows mods to test whether the callback handles certain situations correctly, e.g. formspecs where some parts are conditionally hidden but have only one callback function (which also need to have the code to make sure certain fields are not handled when they are not supposed to be).