### PR TITLE
Random refab

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -10,9 +10,39 @@ jobs:
       with:
         path: mineunit
     - id: mineunit
-      uses: mt-mods/mineunit-actions@master
+      name: mineunit
+      uses: mt-mods/mineunit-actions@dev
       with:
         working-directory: mineunit
+    - id: mineunit541
+      name: mineunit 5.4.1
+      uses: mt-mods/mineunit-actions@dev
+      with:
+        coverage: false
+        mineunit-args: --engine-version 5.4.1
+        working-directory: mineunit
+    - id: mineunit551
+      name: mineunit 5.5.1
+      uses: mt-mods/mineunit-actions@dev
+      with:
+        coverage: false
+        mineunit-args: --engine-version 5.5.1
+        working-directory: mineunit
+    - id: mineunit561
+      name: mineunit 5.6.1
+      uses: mt-mods/mineunit-actions@dev
+      with:
+        coverage: false
+        mineunit-args: --engine-version 5.6.1
+        working-directory: mineunit
+    - id: mineunit570
+      name: mineunit 5.7.0
+      uses: mt-mods/mineunit-actions@dev
+      with:
+        coverage: false
+        mineunit-args: --engine-version 5.7.0
+        working-directory: mineunit
+
     - uses: RubbaBoy/BYOB@v1.3.0
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
@@ -21,8 +51,9 @@ jobs:
         STATUS: "${{ steps.mineunit.outputs.badge-status }}"
         COLOR: "${{ steps.mineunit.outputs.badge-color }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - uses: KeisukeYamashita/create-comment@v1
-      if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      if: failure() && steps.mineunit.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       with:
         check-only-first-line: true
         comment: |
@@ -30,6 +61,43 @@ jobs:
           ```
           ${{ steps.mineunit.outputs.mineunit-stdout }}
           ```
+    - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && steps.mineunit541.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        check-only-first-line: true
+        comment: |
+          ## Some tests failed, test log follows:
+          ```
+          ${{ steps.mineunit541.outputs.mineunit-stdout }}
+          ```
+    - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && steps.mineunit551.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        check-only-first-line: true
+        comment: |
+          ## Some tests failed, test log follows:
+          ```
+          ${{ steps.mineunit551.outputs.mineunit-stdout }}
+          ```
+    - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && steps.mineunit561.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        check-only-first-line: true
+        comment: |
+          ## Some tests failed, test log follows:
+          ```
+          ${{ steps.mineunit561.outputs.mineunit-stdout }}
+          ```
+    - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && steps.mineunit570.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        check-only-first-line: true
+        comment: |
+          ## Some tests failed, test log follows:
+          ```
+          ${{ steps.mineunit570.outputs.mineunit-stdout }}
+          ```
+
     - uses: KeisukeYamashita/create-comment@v1
       if: success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       with:

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,13 +28,32 @@ files["./jit-p.lua"].ignore = { "561" }
 files["./assert.lua"].globals = { "type" }
 files["./init.lua"].globals = { "mineunit", "fixture", "fixture_path", "sourcefile", }
 files["./globals.lua"].globals = { "INIT", "PLATFORM", "DIR_DELIM" }
-files["./globals.lua"].read_globals = Writable{ mineunit = { "set_timeofday" } }
+files["./globals.lua"].read_globals = Writable{
+	mineunit = {
+		"utils",
+		"set_timeofday"
+	},
+}
 files["./settings.lua"].read_globals = Writable{ mineunit = { "apply_default_settings" } }
 files["./auth.lua"].read_globals = Writable{ mineunit = { "create_auth" } }
-files["./craft.lua"].read_globals = Writable{ mineunit = { "CraftManager" } }
+files["./craft.lua"].read_globals = Writable{
+	mineunit = { "CraftManager" },
+	core = {
+		"get_all_craft_recipes",
+		"register_craft",
+		"clear_craft",
+		"get_craft_result",
+	}
+}
 files["./player.lua"].read_globals = Writable{ mineunit = { "get_players" } }
 files["./entity.lua"].read_globals = Writable{ mineunit = { "get_entities" } }
-files["./protection.lua"].read_globals = Writable{ mineunit = { "protect" } }
+files["./protection.lua"].read_globals = Writable{
+	mineunit = { "protect" },
+	core = {
+		"is_protected",
+		"record_protection_violation",
+	}
+}
 files["./print.lua"].globals = { "dump" }
 files["./print.lua"].read_globals = Writable{
 	mineunit = {
@@ -72,23 +91,30 @@ files["./metadata.lua"].read_globals = Writable{
 		"clear_InvRef",
 	}
 }
-files["./http.lua"].read_globals = Writable{ mineunit = { "http_server" } }
+files["./http.lua"].read_globals = Writable{
+	mineunit = { "http_server" },
+	core = { "request_http_api" },
+}
 files["./fs.lua"].read_globals = Writable{
 	mineunit = {
 		"fs_reset",
 		"fs_copy",
 		"fs_getfile",
 		"fs_raw"
+	},
+	core = {
+		"mkdir",
+		"get_dir_list",
 	}
 }
 
 files["./core.lua"].globals = { "world" }
-files["./voxelmanip.lua"].read_globals = Writable{ world = { "nodes" } }
+files["./voxelmanip.lua"].read_globals = Writable{
+	world = { "nodes" },
+	core = { "get_voxel_manip" },
+}
 
 globals = {
-	-- Engine
-	"core", "minetest", "vector", "dump2",
-
 	-- MTG
 	"default",
 }
@@ -168,26 +194,31 @@ read_globals = {
 		-- subtables and other objects
 		CraftManager = {},
 		utils = { fields = {
-			"sequential", -- function (t)
 			"count", -- function (t)
-			"tabletype", -- function (t)
-			"in_array", -- function (t, value)
-			"round", -- function (value)
-			"is_coordinate", -- function (thing)
-			"is_valid_name", -- function (name)
 			"format_coordinate", -- function (t)
 			--"has_item", -- assertion validator, should probably be removed
-			"type", -- function (thing)
+			"in_array", -- function (t, value)
+			"is_coordinate", -- function (thing)
+			"is_valid_name", -- function (name)
 			"luatype", -- function (thing)
+			"noop", -- function (...)
+			"round", -- function (value)
+			"sequential", -- function (t)
+			"tabletype", -- function (t)
+			"type", -- function (thing)
 		}}
 	}},
 	"world",
 	"NodeTimerRef", "MetaDataRef", "NodeMetaRef", "ObjectRef", "InvRef", "Player",
 
 	-- Engine
+	"core", "minetest",
+
 	"INIT", "PLATFORM", "DIR_DELIM",
 	string = {fields = {"split", "trim"}},
 	table = {fields = {"copy", "getn", "indexof", "insert_all", "key_value_swap", "shuffle"}},
 	math = {fields = {"hypot", "sign", "factorial"}},
+	vector = {fields = {"new", "add", "subtract", "direction", "round", "floor", "divide", "multiply", "sort"}},
 	"PseudoRandom", "ItemStack", "VoxelArea", "VoxelManip", "Settings",
+
 }

--- a/assert.lua
+++ b/assert.lua
@@ -2,6 +2,8 @@
 
 local lua_type = type
 
+local function noop() end
+
 local function mineunit_type(obj)
 	if lua_type(obj) == "table" then
 		return rawget(obj, "_mineunit_typename")
@@ -357,15 +359,16 @@ _G.assert = assert
 -- TODO: Something wrong with this
 
 return {
-	sequential = sequential,
 	count = count,
-	tabletype = tabletype,
-	in_array = in_array,
-	round = round,
-	is_coordinate = is_coordinate,
-	is_valid_name = is_valid_name,
 	format_coordinate = format_coordinate,
 	has_item = has_item,
-	type = mineunit_type,
+	in_array = in_array,
+	is_coordinate = is_coordinate,
+	is_valid_name = is_valid_name,
 	luatype = lua_type,
+	noop = noop,
+	round = round,
+	sequential = sequential,
+	tabletype = tabletype,
+	type = mineunit_type,
 }

--- a/core.lua
+++ b/core.lua
@@ -1,25 +1,20 @@
-local function noop(...) end
+local noop = mineunit.utils.noop
 local noop_object = {
-	__call = function(self,...) return self end,
-	__index = function(...) return function(...)end end,
+	__call = function(self) return self end,
+	__index = function() return noop end,
 }
+local engine_version = mineunit:config("engine_version")
+local engine_version_minor = tonumber(engine_version:sub(3,3)) or -1
 
 mineunit("craft")
 mineunit("world")
 
-_G.core.is_singleplayer = function() return mineunit:config("singleplayer") end
 _G.core.notify_authentication_modified = noop
 
 _G.core.set_node = world.set_node
 _G.core.add_node = world.set_node
 _G.core.swap_node = world.swap_node
 
-_G.core.get_worldpath = function(...) return _G.mineunit:get_worldpath(...) end
-_G.core.get_modpath = function(...) return _G.mineunit:get_modpath(...) end
-_G.core.get_current_modname = function(...) return _G.mineunit:get_current_modname(...) end
-_G.core.register_item_raw = noop
-_G.core.unregister_item_raw = noop
-_G.core.register_alias_raw = noop
 _G.core.get_translator = function(...) return function(...) mineunit:debug(...) end end
 _G.core.set_http_api_lua = noop
 _G.core.inventorycube = function(img1, img2, img3)
@@ -39,11 +34,14 @@ mineunit:apply_default_settings(_G.core.settings)
 _G.core.register_on_joinplayer = noop
 _G.core.register_on_leaveplayer = noop
 
-_G.minetest.register_on_player_receive_fields = noop
+_G.core.register_on_player_receive_fields = noop
 
 mineunit("game/constants")
 mineunit("common/vector")
 mineunit("game/item")
+if engine_version_minor > 5 then
+	mineunit("game/misc_s")
+end
 mineunit("game/misc")
 mineunit("game/register")
 mineunit("common/misc_helpers")
@@ -52,10 +50,10 @@ mineunit("game/features")
 mineunit("common/serialize")
 mineunit("fs")
 
-assert(minetest.registered_nodes["air"])
-assert(minetest.registered_nodes["ignore"])
-assert(minetest.registered_items[""])
-assert(minetest.registered_items["unknown"])
+assert(core.registered_nodes["air"])
+assert(core.registered_nodes["ignore"])
+assert(core.registered_items[""])
+assert(core.registered_items["unknown"])
 
 mineunit("metadata")
 mineunit("itemstack")
@@ -105,37 +103,37 @@ _G.core.remove_detached_inventory = function(name)
 	return false
 end
 
-_G.minetest.sound_play = noop
-_G.minetest.sound_stop = noop
-_G.minetest.sound_fade = noop
-_G.minetest.add_particlespawner = noop
+_G.core.sound_play = noop
+_G.core.sound_stop = noop
+_G.core.sound_fade = noop
+_G.core.add_particlespawner = noop
 
-_G.minetest.registered_chatcommands = {}
-_G.minetest.register_chatcommand = noop
-_G.minetest.chat_send_player = function(...) print(unpack({...})) end
-_G.minetest.chat_send_all = function(...) print(unpack({...})) end
-_G.minetest.register_on_placenode = noop
-_G.minetest.register_on_dignode = noop
-_G.minetest.register_on_mods_loaded = function(func) mineunit:register_on_mods_loaded(func) end
+_G.core.registered_chatcommands = {}
+_G.core.register_chatcommand = noop
+_G.core.chat_send_player = function(...) print(unpack({...})) end
+_G.core.chat_send_all = function(...) print(unpack({...})) end
+_G.core.register_on_placenode = noop
+_G.core.register_on_dignode = noop
+_G.core.register_on_mods_loaded = function(func) mineunit:register_on_mods_loaded(func) end
 
-_G.minetest.item_drop = noop
-_G.minetest.add_item = noop
-_G.minetest.check_for_falling = noop
-_G.minetest.get_objects_inside_radius = function(...) return {} end
+_G.core.item_drop = noop
+_G.core.add_item = noop
+_G.core.check_for_falling = noop
+_G.core.get_objects_inside_radius = function(...) return {} end
 
-_G.minetest.register_biome = noop
-_G.minetest.clear_registered_biomes = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
-_G.minetest.register_ore = noop
-_G.minetest.clear_registered_ores = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
-_G.minetest.register_decoration = noop
-_G.minetest.clear_registered_decorations = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
+_G.core.register_biome = noop
+_G.core.clear_registered_biomes = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
+_G.core.register_ore = noop
+_G.core.clear_registered_ores = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
+_G.core.register_decoration = noop
+_G.core.clear_registered_decorations = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
 
 do
 	local time_step = tonumber(mineunit:config("time_step"))
 	assert(time_step, "Invalid configuration value for time_step. Number expected.")
 	if time_step < 0 then
 		mineunit:info("Running default core.get_us_time using real world wall clock.")
-		_G.minetest.get_us_time = function()
+		_G.core.get_us_time = function()
 			local socket = require 'socket'
 			-- FIXME: Returns the time in seconds, relative to the origin of the universe.
 			return socket.gettime() * 1000 * 1000
@@ -143,31 +141,31 @@ do
 	else
 		mineunit:info("Running custom core.get_us_time with step increment: "..tostring(time_step))
 		local time_now = 0
-		_G.minetest.get_us_time = function()
+		_G.core.get_us_time = function()
 			time_now = time_now + time_step
 			return time_now
 		end
 	end
 end
 
-_G.minetest.after = noop
+_G.core.after = noop
 
-_G.minetest.find_nodes_with_meta = _G.world.find_nodes_with_meta
-_G.minetest.find_nodes_in_area = _G.world.find_nodes_in_area
-_G.minetest.get_node_or_nil = _G.world.get_node
-_G.minetest.get_node = function(pos) return minetest.get_node_or_nil(pos) or {name="ignore",param1=0,param2=0} end
-_G.minetest.dig_node = function(pos) return world.on_dig(pos) and true or false end
-_G.minetest.remove_node = _G.world.remove_node
-_G.minetest.load_area = noop
+_G.core.find_nodes_with_meta = _G.world.find_nodes_with_meta
+_G.core.find_nodes_in_area = _G.world.find_nodes_in_area
+_G.core.get_node_or_nil = _G.world.get_node
+_G.core.get_node = function(pos) return core.get_node_or_nil(pos) or {name="ignore",param1=0,param2=0} end
+_G.core.dig_node = function(pos) return world.on_dig(pos) and true or false end
+_G.core.remove_node = _G.world.remove_node
+_G.core.load_area = noop
 
-_G.minetest.get_node_timer = {}
-setmetatable(_G.minetest.get_node_timer, noop_object)
+_G.core.get_node_timer = {}
+setmetatable(_G.core.get_node_timer, noop_object)
 
 local content_name2id = {}
 local content_id2name = {}
-_G.minetest.get_content_id = function(name)
+_G.core.get_content_id = function(name)
 	-- check if the node exists
-	assert(minetest.registered_nodes[name], "node " .. name .. " is not registered")
+	assert(core.registered_nodes[name], "node " .. name .. " is not registered")
 
 	-- create and increment
 	if not content_name2id[name] then
@@ -177,7 +175,7 @@ _G.minetest.get_content_id = function(name)
 	return content_name2id[name]
 end
 
-_G.minetest.get_name_from_content_id = function(cid)
+_G.core.get_name_from_content_id = function(cid)
 	assert(content_id2name[cid+1], "Unknown content id")
 	return content_id2name[cid+1]
 end

--- a/globals.lua
+++ b/globals.lua
@@ -4,9 +4,11 @@
 -- https://github.com/minetest/minetest/blob/master/src/script/cpp_api/s_base.cpp
 -- https://github.com/minetest/minetest/blob/master/src/porting.h
 
--- Libraries
+-- Load basic libraries and Mineunit assertions
 
 local assert = require('luassert.assert')
+mineunit.utils = require("mineunit.assert")
+local noop = mineunit.utils.noop
 
 -- Constants
 
@@ -18,12 +20,27 @@ DIR_DELIM = "/"
 -- Engine API
 
 local core = {}
-_G.core = core
+
+core.register_item_raw = noop
+core.unregister_item_raw = noop
+core.register_alias_raw = noop
 
 function core.get_builtin_path()
 	local tag = mineunit:config("engine_version")
 	return (tag == "mineunit" and mineunit:config("mineunit_path")
 		or mineunit:config("core_root") .. DIR_DELIM .. tag) .. DIR_DELIM
+end
+
+function core.get_worldpath(...)
+	return mineunit:get_worldpath(...)
+end
+
+function core.get_modpath(...)
+	return mineunit:get_modpath(...)
+end
+
+function core.get_current_modname(...)
+	return mineunit:get_current_modname(...)
 end
 
 function core.global_exists(name)
@@ -50,6 +67,10 @@ function core.gettext(value)
 	return value
 end
 
+function core.is_singleplayer()
+	return mineunit:config("singleplayer")
+end
+
 local core_timeofday = 0.5
 function core.get_timeofday()
 	return core_timeofday
@@ -64,6 +85,10 @@ end
 function core.get_node_light(pos, timeofday)
 	timeofday = timeofday or core.get_timeofday()
 	return mineunit.utils.round(math.sin(timeofday * 3.14) * 15)
+end
+
+function core.compare_block_status(pos, status)
+	return true
 end
 
 local json = require('mineunit.lib.json')
@@ -83,3 +108,13 @@ end
 local origin
 function core.get_last_run_mod() return origin end
 function core.set_last_run_mod(v) origin = v end
+
+-- Engine version compatibility
+
+-- 5.6.x releases had vector defined in engine
+_G.vector = { metatable = {} }
+
+-- Set engine core and its aliases
+
+_G.core = core
+_G.minetest = core

--- a/init.lua
+++ b/init.lua
@@ -259,7 +259,6 @@ function mineunit.export_object(obj, def)
 	end
 end
 
-mineunit.utils = mineunit("assert")
 local sequential = mineunit.utils.sequential
 
 function mineunit.deep_merge(data, target, defaults)

--- a/protection.lua
+++ b/protection.lua
@@ -7,17 +7,17 @@ function mineunit:protect(pos, name_or_player)
 	assert(type(name_or_player) == "string" or type(name_or_player) == "userdata",
 		"mineunit:protect name_or_player should be string or userdata")
 	local name = type(name_or_player) == "userdata" and name_or_player:get_player_name() or name_or_player
-	protected_nodes[minetest.hash_node_position(pos)] = name
+	protected_nodes[core.hash_node_position(pos)] = name
 end
 
-minetest.is_protected = function(pos, name)
-	local nodeid = minetest.hash_node_position(pos)
+core.is_protected = function(pos, name)
+	local nodeid = core.hash_node_position(pos)
 	if protected_nodes[nodeid] == nil or protected_nodes[nodeid] == name then
 		return false
 	end
 	return true
 end
 
-minetest.record_protection_violation = function(...)
-	print("minetest.record_protection_violation", ...)
+core.record_protection_violation = function(...)
+	print("core.record_protection_violation", ...)
 end

--- a/spec/itemstack_spec.lua
+++ b/spec/itemstack_spec.lua
@@ -8,7 +8,9 @@ describe("ItemStack", function()
 	mineunit:config_set("silence_global_export_overrides", true)
 	sourcefile("itemstack")
 
+	--luacheck:push ignore 122 setting read-only field
 	core.registered_items = {
+	--luacheck:pop
 		test = { stack_max = 100 }
 	}
 

--- a/spec/metadata_spec.lua
+++ b/spec/metadata_spec.lua
@@ -9,7 +9,9 @@ describe("NodeMetaRef", function()
 	sourcefile("itemstack")
 	sourcefile("metadata")
 
+	--luacheck:push ignore 122 setting read-only field
 	core.registered_items = {
+	--luacheck:pop
 		test = { stack_max = 100 },
 		foo = { stack_max = 50 }
 	}

--- a/world.lua
+++ b/world.lua
@@ -263,9 +263,5 @@ function world.add_layout(layout, offset)
 	end
 end
 
-function core.compare_block_status(pos, status)
-	return true
-end
-
 _G.world = world
 return world


### PR DESCRIPTION
### Updates

* Increases compatibility with engine version >= 5.6.1
* Adds self tests for 5.4.1, 5.5.1, 5.6.1 and 5.7.0
* Some refactoring for future updates

### Basic smoke tests

| Tested mod              | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests     | 231     | 0      | 0     | 1       | 0.883594 |
| Mineunit demo spec      | 8       | 0      | 0     | 1       | 0.027931 |
| advtrains/advtrains     | 22      | 0      | 0     | 0       | 0.017276 |
| advtrains/serialize_lib | 5       | 0      | 0     | 0       | 0.013398 |
| archtec                 | 5       | 0      | 0     | 1       | 0.016758 |
| beerchat                | 161     | 0      | 0     | 1       | 0.347924 |
| geoip                   | 11      | 0      | 0     | 2       | 0.034161 |
| machine_parts           | 5       | 0      | 0     | 0       | 0.029749 |
| mesecons                | 20      | 0      | 0     | 0       | 1.045325 |
| mesecons_mvps           | 19      | 0      | 0     | 3       | 0.216399 |
| mesecons_fpga           | 28      | 0      | 0     | 0       | 1.323877 |
| mesecons_luacontroller  | 12      | 0      | 0     | 0       | 0.291027 |
| metatool                | 21      | 0      | 0     | 0       | 0.028077 |
| containertool           | 10      | 0      | 0     | 0       | 0.022453 |
| sharetool               | 15      | 0      | 0     | 0       | 0.02524  |
| tubetool                | 33      | 0      | 0     | 0       | 0.024691 |
| spectator_mode          | 21      | 0      | 0     | 0       | 0.024346 |
| qos                     | 31      | 0      | 0     | 3       | 0.064871 |
| technic/technic         | 243     | 0      | 0     | 4       | 4.004094 |
| technic/technic_cnc     | 31      | 0      | 0     | 0       | 0.340797 |
| technic/technic_chests  | 5       | 0      | 0     | 0       | 0.021209 |