### PR TITLE
Engine version compat 0.15

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -13,6 +13,14 @@ jobs:
       name: mineunit
       uses: mt-mods/mineunit-actions@dev
       with:
+        coverage: true
+        working-directory: mineunit
+    - id: mineunitdd
+      name: mineunit dynamic debug
+      uses: mt-mods/mineunit-actions@dev
+      with:
+        coverage: true
+        mineunit-args: --dynamic-debug
         working-directory: mineunit
     - id: mineunit541
       name: mineunit 5.4.1
@@ -62,6 +70,15 @@ jobs:
           ${{ steps.mineunit.outputs.mineunit-stdout }}
           ```
     - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && steps.mineunitdd.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        check-only-first-line: true
+        comment: |
+          ## Some tests failed, test log follows:
+          ```
+          ${{ steps.mineunitdd.outputs.mineunit-stdout }}
+          ```
+    - uses: KeisukeYamashita/create-comment@v1
       if: failure() && steps.mineunit541.conclusion == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       with:
         check-only-first-line: true
@@ -103,9 +120,11 @@ jobs:
       with:
         check-only-first-line: true
         comment: |
-          <details><summary><i>Click for detailed source code test coverage report</i></summary>
+          #### Test coverage ${{ steps.mineunit.outputs.coverage-total }} in ${{ steps.mineunit.outputs.coverage-files }} files (higher is better).
           
-          #### Test coverage ${{ steps.mineunit.outputs.coverage-total }} in ${{ steps.mineunit.outputs.coverage-files }} files:
+          **Dynamic debug coverage ${{ steps.mineunitdd.outputs.coverage-total }} in ${{ steps.mineunitdd.outputs.coverage-files }} files (lower is better).**
+          
+          <details><summary><i>Click for detailed source code test coverage report</i></summary>
           
           ```q
           File                                      Hits Missed Coverage

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,6 +7,7 @@ exclude_files = {
 	"./core/**",
 	"./common/**",
 	"./game/**",
+	"./.**/**"
 }
 
 local function Writable(what)
@@ -26,12 +27,24 @@ files["./jit-p.lua"].ignore = { "561" }
 
 -- Mineunit source files
 files["./assert.lua"].globals = { "type" }
+files["./assert.lua"].read_globals = Writable{
+	mineunit = {
+		"debughooks",
+	},
+}
 files["./init.lua"].globals = { "mineunit", "fixture", "fixture_path", "sourcefile", }
+files["./config.lua"].read_globals = Writable{
+	mineunit = {
+		"_config",
+		"config",
+		"config_set",
+	},
+}
 files["./globals.lua"].globals = { "INIT", "PLATFORM", "DIR_DELIM" }
 files["./globals.lua"].read_globals = Writable{
 	mineunit = {
 		"utils",
-		"set_timeofday"
+		"set_timeofday",
 	},
 }
 files["./settings.lua"].read_globals = Writable{ mineunit = { "apply_default_settings" } }
@@ -62,6 +75,7 @@ files["./protection.lua"].read_globals = Writable{
 files["./print.lua"].globals = { "dump" }
 files["./print.lua"].read_globals = Writable{
 	mineunit = {
+		"format",
 		"prepend_print",
 		"prepend_flush",
 		"debug",
@@ -113,22 +127,26 @@ files["./fs.lua"].read_globals = Writable{
 		"fs_reset",
 		"fs_copy",
 		"fs_getfile",
-		"fs_raw"
+		"fs_raw",
 	},
 	core = {
 		"mkdir",
 		"get_dir_list",
 	}
 }
-
-files["./core.lua"].globals = { "world" }
+files["./core.lua"].read_globals = Writable{
+	core = {
+		"send_join_message",
+		"send_leave_message",
+	}
+}
 files["./voxelmanip.lua"].read_globals = Writable{
 	world = { "nodes" },
 	core = { "get_voxel_manip" },
 }
 
 globals = {
-	-- MTG
+	-- FIXME: MTG
 	"default",
 }
 
@@ -153,8 +171,10 @@ read_globals = {
 	"fixture", "fixture_path", "sourcefile",
 	mineunit = { fields = {
 		-- static functions
-		"deep_merge", -- function (data, target, defaults)
+		"dofile", -- function (path, ...)
 		"export_object", -- function (obj, def)
+		"loadfile", -- function (path, ...)
+		"format", -- function (fmtstr, ...)
 		-- instance methods
 		"apply_default_settings", -- function (self, settings)
 		"builtin", -- function (self, name)
@@ -210,6 +230,7 @@ read_globals = {
 		Form = {},
 		utils = { fields = {
 			"count", -- function (t)
+			"explode_version", -- function(versionstring, default)
 			"format_coordinate", -- function (t)
 			--"has_item", -- assertion validator, should probably be removed
 			"in_array", -- function (t, value)
@@ -221,7 +242,20 @@ read_globals = {
 			"sequential", -- function (t)
 			"tabletype", -- function (t)
 			"type", -- function (thing)
-		}}
+		}},
+		debughooks = { fields = {
+			"available",
+			"noop",
+			"restore",
+			"delete",
+			"push",
+			"pop",
+			"get",
+			"call",
+			"reset",
+			"enable",
+			"disable",
+		}},
 	}},
 	"world",
 	"NodeTimerRef", "MetaDataRef", "NodeMetaRef", "ObjectRef", "InvRef", "Player",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -45,7 +45,12 @@ files["./craft.lua"].read_globals = Writable{
 		"get_craft_result",
 	}
 }
-files["./player.lua"].read_globals = Writable{ mineunit = { "get_players" } }
+files["./player.lua"].read_globals = Writable{
+	mineunit = {
+		"get_player_formspec",
+		"get_players",
+	}
+}
 files["./entity.lua"].read_globals = Writable{ mineunit = { "get_entities" } }
 files["./protection.lua"].read_globals = Writable{
 	mineunit = { "protect" },
@@ -95,6 +100,14 @@ files["./http.lua"].read_globals = Writable{
 	mineunit = { "http_server" },
 	core = { "request_http_api" },
 }
+files["./formspec.lua"].read_globals = Writable{
+	mineunit = {
+		"Form",
+		"send_formspec_fields",
+		"set_formspec_fields",
+		"set_formspec_field",
+	}
+}
 files["./fs.lua"].read_globals = Writable{
 	mineunit = {
 		"fs_reset",
@@ -122,9 +135,9 @@ globals = {
 read_globals = {
 	-- luassert
 	assert = { fields = {
-		"string", "table", "player_or_name", "ItemStack", "Player", "coordinate",
-		"is_string", "is_table", "is_player_or_name", "is_ItemStack", "is_Player", "is_coordinate",
-		"not_string", "not_table", "not_player_or_name", "not_ItemStack", "not_Player", "not_coordinate",
+		"string", "table", "player_or_name", "ItemStack", "Player", "coordinate", --"Form",
+		"is_string", "is_table", "is_player_or_name", "is_ItemStack", "is_Player", "is_coordinate", --"is_Form",
+		"not_string", "not_table", "not_player_or_name", "not_ItemStack", "not_Player", "not_coordinate", --"not_Form",
 
 		"itemstring", "itemname", "number", "integer", "indexed", "hashed", "in_array",
 		"is_itemstring", "is_itemname", "is_number", "is_integer", "is_indexed", "is_hashed", "is_in_array",
@@ -172,6 +185,7 @@ read_globals = {
 		"get_entities", -- function (self, )
 		"get_InvRef_data", -- function (self, thing)
 		"get_modpath", -- function (self, name)
+		"get_player_formspec", -- function (self, player_or_name)
 		"get_players", -- function (self, )
 		"get_worldpath", -- function (self, )
 		"has_module", -- function (self, name)
@@ -193,6 +207,7 @@ read_globals = {
 		"warning", -- function (self, ...)
 		-- subtables and other objects
 		CraftManager = {},
+		Form = {},
 		utils = { fields = {
 			"count", -- function (t)
 			"format_coordinate", -- function (t)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Github integration is available to automatically execute tests when new code is 
 ### How to use mineunit
 
 Recommended way is docker, it keeps both Mineunit and mod code isolated.
-Docker images are also currenlty best way to get latest features.
+Docker images are also current best way to get latest features.
 See https://hub.docker.com/r/mineunit/mineunit for more information.
 
 You can also install Mineunit from luarocks and create spec directory for tests:
@@ -199,16 +199,23 @@ For tests that depend oon players it can be useful to register `before_each` and
 | `mineunit:warning(...)`          | Prints to console if `verbose` option is higher than 1.
 | `mineunit:error(...)`            | Prints to console if `verbose` option is higher than 0.
 | `mineunit:print(...)`            | Prints to console if `print` option is enabled.
-| `mineunit:debugf(fmtstr, ...)`   | Like `debug` but with format string. Based on custom `string.format`, details below.
-| `mineunit:infof(fmtstr, ...)`    | Like `info` but with format string. Based on custom `string.format`, details below.
-| `mineunit:warningf(fmtstr, ...)` | Like `warning` but with format string. Based on custom `string.format`, details below.
-| `mineunit:errorf(fmtstr, ...)`   | Like `error` but with format string. Based on custom `string.format`, details below.
-| `mineunit:printf(fmtstr, ...)`   | Like `print` but with format string. Based on custom `string.format`, details below.
+| `mineunit:debugf(fmtstr, ...)`   | Like `debug` but with format string. Uses `mineunit.format`.
+| `mineunit:infof(fmtstr, ...)`    | Like `info` but with format string. Uses `mineunit.format`.
+| `mineunit:warningf(fmtstr, ...)` | Like `warning` but with format string. Uses `mineunit.format`.
+| `mineunit:errorf(fmtstr, ...)`   | Like `error` but with format string. Uses `mineunit.format`.
+| `mineunit:printf(fmtstr, ...)`   | Like `print` but with format string. Uses `mineunit.format`.
+| `mineunit.format(fmtstr, ...)`   | Formatter used with above methods. Custom formatter similar to `string.format`.
 
-Format strings for above `*f` functions accept default Lua format strings with few exceptions.
-String formatter `%s` can accept any argument type and will do special formatting for some common
-data such as coordinates, pointed_thing and such. This holds for both Lua 5.1 and LuaJIT.
-Additional `%t` formatter simply uses `dump` for everything. Besides that, same as Lua `string.format`.
+Format strings for above `*f` functions accepts default Lua format strings with few exceptions and extras:
+
+* String formatter `%s` can accept any argument type and will do special formatting for some data types
+  like coordinates and pointed_thing. Ability to accept any type is for both Lua 5.1 and LuaJIT versions.
+* Plain hexadecimal formatter `%x` dumps strings as hexadecimal sequences.
+* Additional `%@` formatter expands to source file path and line number, does not consume arguments.
+  Accepts additional number to get source line at different level in call stack, for example `%@1`.
+* Additional `%t` formatter simply uses `dump` for everything.
+
+Besides that, same as Lua `string.format`.
 
 #### Mostly internal / questionable / possibly unstable utility functions
 
@@ -259,6 +266,95 @@ Anyway, these might help a bit. And taking a look at other mods utilizing mineun
 
 It is recommended to always load `core` module instead of selecting individual automatically loaded modules.
 
+#### formspec module
+
+(!) EXPERIMENTAL / UNSTABLE FEATURE, api might change at any time without warning.
+
+`mineunit("formspec")` will load formspec module which provides `Form` class, formspec parsing and formspec actions.
+This module is also loaded as a dependency for `player` module.
+
+Constructor for `Form` class instances:
+
+* `mineunit:Form(formname, formspec)` returns new `Form` instance based on two strings: form name and formspec.
+* `mineunit:Form()` returns constructor. This constructor can be called as above or can be used to call static functions.
+
+API for `Form` instances:
+
+| Method                                | Description
+| ------------------------------------- | -----------------------------------------------------------------
+| `form:find(namepattern, typepattern)` | Find elements based on Lua patterns. Requires at least one arguent. Returns iterator.
+| `form:one(namepattern, typepattern)`  | Find element based on Lua patterns. Requires at least one arguent. Returns element.
+| `form:all(namepattern, typepattern)`  | Find elements based on Lua patterns. Requires at least one arguent. Returns array.
+| `form:fields()`                       | Find elements based on Lua patterns. Requires at least one arguent. Returns iterator.
+| `form:value(name, data)`              | Get or set value of named form field.
+| `form:data()`                         | Return direct reference to backing storage table for form elements.
+| `form:text()`                         | Return raw formspec string / text content.
+| `form:name()`                         | Return form name.
+| `form:version()`                      | Not implemented.
+| `form:send(player)`                   | Send formspec to player with current fields.
+| `form:send(player, fields)`           | Send formspec to player with one time custom fields.
+
+Static `Form` functions:
+
+| Function                    | Description
+| --------------------------- | -----------------------------------------------------------------
+| `Form.send(player)`         | Submit open formspec with current fields. Throws error if formspec is not active.
+| `Form.send(player, fields)` | Submit open formspec with one time custom fields. Throws error if formspec is not active.
+
+Mineunit formspec control API:
+
+| Method                                                  | Description
+| ------------------------------------------------------- | ------------------------------------------------------------
+| mineunit:get_player_formspec(player_or_name)            | Return current `Form` of player or `nil` if no formspec is active.
+| mineunit:send_formspec_fields(player_or_name, fields)   | Should be avoided, likely removed in future releases.
+| mineunit:set_formspec_fields(player_or_name, fields)    | Should be avoided, likely removed in future releases.
+| mineunit:set_formspec_field(player_or_name, key, value) | Should be avoided, likely removed in future releases.
+
+Example use:
+
+Tested mod should be able to receive formspec, check if the `"query"` field value is `"Meaning of life?"` and
+respond with a form that has textarea named `"answer"` containing `"42"` as an answer to the query.
+
+Player gets response form when query form is submitted, check that response form has expected elements and values.
+
+```lua
+describe("my query form", function()
+	local Sam = Player("Sam")
+
+	before_each(function()
+		mineunit:execute_on_joinplayer(Sam)
+	end)
+
+	after_each(function()
+		mineunit:execute_on_leaveplayer(Sam)
+	end)
+
+	it("gives correct answer", function()
+		-- Close response form after test has completed, also if test has failed
+		finally(function()
+			core.close_formspec(Sam:get_player_name())
+		end)
+
+		-- Open formspec, depending on mod this could be replaced with chat command or maybe right click on node
+		core.show_formspec("Sam", "myform", "field[query;Ask something;ask anything]")
+
+		-- Player should have received a from, set query field value and submit form
+		local queryform = mineunit:get_player_formspec(Sam)
+		assert.is_Form(queryform)
+		local queryfield = queryform:one("query", "field")
+		queryfield:value("Meaning of life?")
+		queryform:send("Sam")
+
+		-- Get response form and make sure it contains textarea named mytext with expected value
+		local responseform = mineunit:get_player_formspec(Sam)
+		assert.is_Form(responseform)
+		local textarea = responseform:one("answer", "textarea")
+		assert.not_nil(textarea)
+		assert.match("Answer is 42", textarea:value())
+	end)
+end)
+```
+
 #### Additional modules
 
 | Module name         | Description
@@ -278,10 +374,10 @@ It is recommended to always load `core` module instead of selecting individual a
 ### Command line arguments
 
 ```
-Mineunit v0.14.0 (Lua 5.1)
+Mineunit v0.15.0 (Lua 5.1)
 Usage:
-	mineunit [-c|--coverage] [-v|--verbose] [-q|--quiet] [-x|--exclude <pattern>]
-		[--engine-version <version>] [--fetch-core <version>] [--core-root <path>]
+	mineunit [-c|--coverage] [-v|--verbose] [-q|--quiet] [-x|--exclude <pattern>] [--engine-version <version>]
+		[--fetch-core <version>] [--core-root <path>] [--[no-]dynamic-debug]
 
 Options:
 	-c, --coverage  Execute luacov test coverage analysis.
@@ -308,13 +404,18 @@ Options:
 	                Download core engine libraries for tag.
 	                This is simple wrapper around `git clone`.
 
+	--[no-]dynamic-debug
+	                Enables or disables dynamic debug hooks. Improves --coverage
+	                performance when enabled. Keeps debug hooks always active
+	                when disabled. For now disabled by default.
+
 	-v|--verbose    Be more verbose by printing more useless crap to console.
-	                Can be repeated up to six times for even more annoying output.
+	                Can be repeated up to six times for more annoying output.
 	-q|--quiet      Be quiet, most of time keeps your console fairly clean.
-	                Always disables regular Lua print which can make output
-	                somewhat less annoying when combined with --verbose output.
+	                Always disables regular Lua print making output less annoying
+	                when combined with --verbose output. Twice to shut up.
 	-V|--version    Display Lua and Mineunit version information.
-	-h|--help       Display this cheat sheet.
+	-h|--help       Display this cheat sheet again.
 	--help-assert   Display another cheat sheet, reference for special assertions.
 
 Resources:
@@ -347,7 +448,7 @@ test coverage report called `luacov.report.out`. File is placed in current worki
 With LuaJIT, reports generated by luacov will be broken.
 Run `mineunit -V` to check used Lua version and make sure it is Lua 5.1 instead of LuaJIT.
 
-So basically to get code coverage report you have to run `mineunit` twice, example follows:
+To get code coverage report, you have to run `mineunit` twice, example follows:
 
 ```
 $ mineunit --coverage
@@ -356,8 +457,17 @@ $ mineunit --report
 
 First command executes tests, collects test coverage information and produces coverage data file.
 Second command does not execute tests but reads coverage data file and formats it with source
-code to produce human readable test coverage report file called `luacov.report.out`. Use any
-text editor to read this file.
+code to produce human readable test coverage report file called `luacov.report.out`. Use your
+favorite text editor to read this file.
+
+Collecting coverage information is expensive and reduces performance significantly, it
+is possible to get better performance with _experimental_ `--dynamic-debug` option.
+
+Feature is experimental but works without issues in most cases, expected performance boost would
+be around 20% to 200% depending on nature of tested mod. For example from 1 minute to 30 seconds.
+
+In future `--dynamic-debug` will be enabled by default. If you have to make sure it stays
+disabled in future, use `--no-dynamic-debug` command line option.
 
 ### Known issues
 

--- a/assert.lua
+++ b/assert.lua
@@ -265,6 +265,7 @@ register("player_or_name", 1, "Expected %s to be player or name", function(args)
 end)
 
 local mineunit_types = {
+	"Form",
 	"ItemStack",
 	"InvRef",
 	"MetaDataRef",

--- a/assert.lua
+++ b/assert.lua
@@ -1,3 +1,28 @@
+-- Debug hook control fallback (dynamic debug hooks)
+
+local function noop() end
+mineunit.debughooks = mineunit.debughooks or {
+	call = function(_, fn, ...) fn(...) end,
+	get = function(_, fn, ...) return fn(...) end,
+	noop = noop,
+	restore = noop,
+	delete = noop,
+	push = noop,
+	pop = noop,
+	reset = noop,
+	enable = noop,
+	disable = noop,
+}
+
+local hooks = mineunit.debughooks
+
+-- TODO: Consider either removing dynamic hooks here or complete test coverage for possible scenarios
+local function hooks_restore_if(hooks_enabled)
+	if hooks_enabled then
+		hooks:restore()
+	end
+end
+
 -- Load and configure required modules
 
 local lua_type = type
@@ -10,8 +35,6 @@ assert:set_parameter("TableFormatLevel", 4)
 assert:set_parameter("TableFormatShowRecursion", true)
 
 -- Type overrides
-
-local function noop() end
 
 local function mineunit_type(obj)
 	if lua_type(obj) == "table" then
@@ -335,6 +358,7 @@ end
 -- has_item(coordinate, listname, itemstring|ItemStack)
 -- has_item(coordinate, itemstring|ItemStack)
 local function has_item(state, args)
+	local hooks_enabled = hooks:delete()
 	local inv, list, slot, expected = resolve_args_inv_list_slot_stack(args[1], args[2], args[3], args[4])
 	assert.is_InvRef(inv, "assert.has_item expected Player or coordinates, got "..type(args[1]))
 	assert(type(list) == "string" or list == nil, "Invalid 2nd argument for has_item assertion")
@@ -347,15 +371,22 @@ local function has_item(state, args)
 			local actual = inv:get_stack(list, slot)
 			msg = "Expected %s to have %s but found %s"
 			state.failure_message = msg:format(formatname(args[1]), tostring(expected), tostring(actual))
-			return actual:get_name() == expected:get_name() and actual:get_count() == expected:get_count()
+			local result = actual:get_name() == expected:get_name() and actual:get_count() == expected:get_count()
+			hooks_restore_if(hooks_enabled)
+			return result
+		else
+			local result = inv:contains_item(list, expected)
+			hooks_restore_if(hooks_enabled)
+			return result
 		end
-		return inv:contains_item(list, expected)
 	end
 	for listname in pairs(inv._lists) do
 		if inv:contains_item(listname, expected) then
+			hooks_restore_if(hooks_enabled)
 			return true
 		end
 	end
+	hooks_restore_if(hooks_enabled)
 	return false
 end
 assert:register("assertion", "has_item", has_item)

--- a/assert.lua
+++ b/assert.lua
@@ -1,6 +1,15 @@
--- Type overrides
+-- Load and configure required modules
 
 local lua_type = type
+local spy = require('luassert.spy')
+local assert = require('luassert.assert')
+local format_argument = require('luassert.state').format_argument
+local say = require("say")
+
+assert:set_parameter("TableFormatLevel", 4)
+assert:set_parameter("TableFormatShowRecursion", true)
+
+-- Type overrides
 
 local function noop() end
 
@@ -19,6 +28,12 @@ function type(value)
 end
 
 -- Utilities
+
+local function explode_version(versionstring, default)
+	local m = versionstring:gmatch("%d+")
+	local major, minor, patch = tonumber(m() or default), tonumber(m() or default), tonumber(m() or default)
+	return major, minor, patch
+end
 
 local function round(value)
 	return (value < 0) and math.ceil(value - 0.5) or math.floor(value + 0.5)
@@ -115,7 +130,6 @@ end
 --
 
 -- Patch spy.on method, see https://github.com/Olivine-Labs/luassert/pull/174
-local spy = require('luassert.spy')
 function spy.on(target_table, target_key)
 	assert(target_table, "Invalid argument #1 for spy.on(target_table, target_key)")
 	local s = spy.new(target_table[target_key])
@@ -125,13 +139,6 @@ function spy.on(target_table, target_key)
 	s.target_key = target_key
 	return s
 end
-
-local assert = require('luassert.assert')
-assert:set_parameter("TableFormatLevel", 4)
-assert:set_parameter("TableFormatShowRecursion", true)
-
-local format_argument = require('luassert.state').format_argument
-local say = require("say")
 
 local function register_positive_fmt(name, fmtstr)
 	say:set("assertion." .. name .. ".positive", fmtstr)
@@ -361,6 +368,7 @@ _G.assert = assert
 
 return {
 	count = count,
+	explode_version = explode_version,
 	format_coordinate = format_coordinate,
 	has_item = has_item,
 	in_array = in_array,

--- a/bin/mineunit
+++ b/bin/mineunit
@@ -32,7 +32,7 @@ local args = {
 	Xoutput = {},
 }
 
-mineunit_version = "0.14.2"
+mineunit_version = "0.15.0"
 local luaversion = (function()
 	local jit = rawget(_G, "jit")
 	return jit and jit.version or rawget(_G, "_VERSION")

--- a/bin/mineunit
+++ b/bin/mineunit
@@ -5,6 +5,7 @@ local args = {
 	quiet = false,
 	output = "utfTerminal",
 	coverage = false,
+	dynamic_debug = false,
 	report = false,
 	runner = {
 		include = nil,
@@ -42,10 +43,16 @@ mineunit_version_str = "Mineunit v" .. mineunit_version .. " (" .. luaversion ..
 local mineunit_conf_defaults = {}
 local mineunit_conf_override = {}
 
-local pl = { path = require 'pl.path' }
+local pl_path = require("pl.path")
+
 local lua_dofile = dofile
-function _G.dofile(path, ...)
-	return lua_dofile(pl.path.normpath(path), ...)
+function dofile(path, ...)
+	return lua_dofile(pl_path.normpath(path), ...)
+end
+
+local lua_loadfile = loadfile
+function loadfile(path, ...)
+	return lua_loadfile(pl_path.normpath(path), ...)
 end
 
 local function execread(cmd)
@@ -54,13 +61,11 @@ local function execread(cmd)
 	process:close()
 	assert(type(rawout) == "string" and rawout ~= "")
 	local output, status = rawout:match("^(.-)\n?\n([0-9]+)$")
-	--print("output", "'"..output.."'")
-	--print("status", "'"..status.."'")
 	return tonumber(status), output
 end
 
 local function normpathrel(path)
-	return pl.path.relpath(pl.path.normpath(pl.path.abspath(path)))
+	return pl_path.relpath(pl_path.normpath(pl_path.abspath(path)))
 end
 
 local function run_report()
@@ -157,8 +162,8 @@ local function fetch_core_libraries(tag, target)
 		print("Refusing to use target with spaces double quotes or control characters (sorry for being lazy): " .. target)
 		return false
 	end
-	if pl.path.exists(target) then
-		if pl.path.isdir(target) then
+	if pl_path.exists(target) then
+		if pl_path.isdir(target) then
 			print("Using existing `core` directory for libraries: " .. target)
 		else
 			print("Path `core` exists and is not directory, refusing to continue: " .. target)
@@ -174,8 +179,8 @@ local function fetch_core_libraries(tag, target)
 	end
 
 	-- Check if tag exists
-	local tagdir = pl.path.join(target, tag)
-	if pl.path.exists(tagdir) then
+	local tagdir = pl_path.join(target, tag)
+	if pl_path.exists(tagdir) then
 		print("Path for selected version already exists, remove to download again: " .. tagdir)
 		return true
 	end
@@ -201,8 +206,8 @@ local function fetch_core_libraries(tag, target)
 	end
 
 	-- Get `builtin` from fetchdir, remove fetchdir
-	local libdir = pl.path.join(fetchdir, "builtin")
-	if not pl.path.exists(libdir) then
+	local libdir = pl_path.join(fetchdir, "builtin")
+	if not pl_path.exists(libdir) then
 		print("Seems like `builtin` directory does not exist: " .. libdir)
 		return false
 	end
@@ -239,11 +244,12 @@ do -- Parse cli args
 			print(mineunit_version_str)
 			return
 		elseif v == "-h" or v == "--help" then
-			print(({(mineunit_version_str..[[
-				
+			print(mineunit_version_str)
+			print(({([[\
 				Usage:
 					mineunit [-c|--coverage] [-v|--verbose] [-q|--quiet] [-x|--exclude <pattern>] \
-					[--engine-version <version>] [--fetch-core <version>] [--core-root <path>]
+					[--engine-version <version>] [--fetch-core <version>] [--core-root <path>] \
+					[--[no-]dynamic-debug]
 				
 				Options:
 					-c, --coverage  Execute luacov test coverage analysis.
@@ -270,14 +276,18 @@ do -- Parse cli args
 					                Download core engine libraries for tag.
 					                This is simple wrapper around `git clone`.
 				
+					--[no-]dynamic-debug
+					                Enables or disables dynamic debug hooks. Improves --coverage
+					                performance when enabled. Keeps debug hooks always active
+					                when disabled. For now disabled by default.
+				
 					-v|--verbose    Be more verbose by printing more useless crap to console.
-					                Can be repeated up to six times for even more annoying output.
+					                Can be repeated up to six times for more annoying output.
 					-q|--quiet      Be quiet, most of time keeps your console fairly clean.
-					                Always disables regular Lua print which can make output
-					                somewhat less annoying when combined with --verbose output.
-					                Twice to shut up.
+					                Always disables regular Lua print making output less annoying
+					                when combined with --verbose output. Twice to shut up.
 					-V|--version    Display Lua and Mineunit version information.
-					-h|--help       Display this cheat sheet.
+					-h|--help       Display this cheat sheet again.
 					--help-assert   Display another cheat sheet, reference for special assertions.
 				
 				Resources:
@@ -294,7 +304,7 @@ do -- Parse cli args
 				
 				License:
 					MIT Expat with LGPL libraries, see LICENSE file for details.
-			]]):gsub("([\r\n])\t\t\t\t?", "%1"):gsub(" \\[\r\n]+\t*", " ")})[1])
+			]]):gsub("([\r\n])\t\t\t\t?", "%1"):gsub("(%s?)\\[\r\n]+\t*", "%1")})[1])
 			return
 		elseif v == "--help-assert" then
 			local doc, indenthdr, indent = nil, "    ", 16
@@ -421,28 +431,28 @@ do -- Parse cli args
 			end
 			table.insert(args.luacov.exclude, arg[i])
 		elseif v == "--demo" then
-			if pl.path.exists("init.lua") then
-				if not pl.path.exists("spec") then
+			if pl_path.exists("init.lua") then
+				if not pl_path.exists("spec") then
 					-- Terrible hack to find mineunit current source directory using mineunit.scwd
 					-- And also more terrible hacks because penlight seems to be broken with dot directories...
-					local source = pl.path.normpath(require("mineunit.scwd")) .. pl.path.sep .. "demo_spec"
-					local target = pl.path.normpath(pl.path.abspath(pl.path.currentdir())) .. pl.path.sep .. "spec"
+					local source = pl_path.normpath(require("mineunit.scwd")) .. pl_path.sep .. "demo_spec"
+					local target = pl_path.normpath(pl_path.abspath(pl_path.currentdir())) .. pl_path.sep .. "spec"
 					local pl_dir = require("pl.dir")
 					local success = true
 					if pl_dir.makepath(target) ~= true then
 						success = false
 					else
 						for path in pl_dir.dirtree(source) do
-							local rpath = path:match("^.*%" .. pl.path.sep .. "demo_spec%" .. pl.path.sep .. "(.-)$")
-							if pl.path.isdir(path) then
-								print("Create:", "spec" .. pl.path.sep .. rpath)
-								if pl_dir.makepath(pl.path.join(target, rpath)) ~= true then
+							local rpath = path:match("^.*%" .. pl_path.sep .. "demo_spec%" .. pl_path.sep .. "(.-)$")
+							if pl_path.isdir(path) then
+								print("Create:", "spec" .. pl_path.sep .. rpath)
+								if pl_dir.makepath(pl_path.join(target, rpath)) ~= true then
 									success = false
 									break
 								end
 							else
-								print("Copy:", "spec" .. pl.path.sep .. rpath)
-								if pl_dir.copyfile(path, pl.path.join(target, rpath)) ~= true then
+								print("Copy:", "spec" .. pl_path.sep .. rpath)
+								if pl_dir.copyfile(path, pl_path.join(target, rpath)) ~= true then
 									success = false
 									break
 								end
@@ -467,11 +477,11 @@ do -- Parse cli args
 				print("Missing value for " .. v)
 				return
 			end
-			local target = pl.path.normpath(pl.path.abspath(arg[i]))
-			if not pl.path.exists(target) then
+			local target = pl_path.normpath(pl_path.abspath(arg[i]))
+			if not pl_path.exists(target) then
 				print("Path "..v.." does not exist: " .. target)
 				return
-			elseif not pl.path.isdir(target) then
+			elseif not pl_path.isdir(target) then
 				print("Path "..v.." is not directory, refusing to continue: " .. target)
 				return
 			end
@@ -497,6 +507,10 @@ do -- Parse cli args
 				return
 			end
 			args.fetch_core = arg[i]
+		elseif v == "--dynamic-debug" then
+			args.dynamic_debug = true
+		elseif v == "--no-dynamic-debug" then
+			args.dynamic_debug = false
 		elseif v == "--" then
 			break
 		else
@@ -520,7 +534,7 @@ do -- read configuration files
 	args.engine_version = args.engine_version or mineunit_conf_defaults.engine_version
 end
 
-args.core_root = args.core_root or pl.path.normpath(pl.path.abspath(pl.path.join(require("mineunit.scwd"), "core")))
+args.core_root = args.core_root or pl_path.normpath(pl_path.abspath(pl_path.join(require("mineunit.scwd"), "core")))
 if args.fetch_core then
 	if not fetch_core_libraries(args.fetch_core, args.core_root) then
 		print("Operation --fetch-core "..args.fetch_core.." failed, giving up")
@@ -541,8 +555,8 @@ if args.engine_version and args.engine_version ~= "mineunit" then
 		end
 		return
 	end
-	local tagdir = pl.path.join(args.core_root, args.engine_version)
-	if not pl.path.isdir(tagdir) then
+	local tagdir = pl_path.join(args.core_root, args.engine_version)
+	if not pl_path.isdir(tagdir) then
 		print("Libraries for version "..args.engine_version.." not found from "..tagdir)
 		return
 	end
@@ -555,15 +569,124 @@ if args.report then
 	return
 end
 
+mineunit = {
+	debughooks = {},
+	mineunit_conf_defaults = mineunit_conf_defaults,
+	mineunit_conf_override = mineunit_conf_override,
+}
+
+if not args.coverage or not args.dynamic_debug then
+	local hooks = mineunit.debughooks
+	function hooks:call(fn, ...) fn(...) end
+	function hooks:get(fn, ...) return fn(...) end
+	local function noop() end
+	hooks.noop = noop
+	hooks.restore = noop
+	hooks.delete = noop
+	hooks.push = noop
+	hooks.pop = noop
+	hooks.reset = noop
+	hooks.enable = noop
+	hooks.disable = noop
+else
+	local hooks = mineunit.debughooks
+	local debug = require("debug")
+	local stashed_debughook = nil
+	local counter = {0}
+	hooks.available = true
+	function hooks:noop() end
+	function hooks:pass(fn, ...) return fn(...) end
+	function hooks:restore()
+		if stashed_debughook ~= nil then
+			io.flush()
+			assert(stashed_debughook[1], "Invalid function")
+			assert(#stashed_debughook[2] > 0, "Invalid mask")
+			debug.sethook(unpack(stashed_debughook))
+			stashed_debughook = nil
+			assert(debug.gethook() ~= nil)
+			return true
+		end
+	end
+	function hooks:delete()
+		if stashed_debughook == nil then
+			io.flush()
+			local hook = {debug.gethook()}
+			if hook[1] and #hook[2] > 0 then
+				stashed_debughook = hook
+				debug.sethook(nil)
+				return true
+			end
+		end
+	end
+	function hooks:push()
+		if counter[#counter] > 1 then
+			counter[#counter] = counter[#counter] - 1
+		else
+			counter[#counter] = 0
+			self:restore()
+		end
+	end
+	function hooks:pop()
+		self:delete()
+		counter[#counter] = counter[#counter] + 1
+	end
+	function hooks:call(fn, ...)
+		counter[#counter + 1] = 0
+		local hooks_disabled = self:restore()
+		fn(...)
+		if hooks_disabled then
+			self:delete()
+		end
+		counter[#counter] = nil
+	end
+	function hooks:get(fn, ...)
+		counter[#counter + 1] = 0
+		local hooks_disabled = self:restore()
+		local result = {fn(...)}
+		if hooks_disabled then
+			self:delete()
+		end
+		counter[#counter] = nil
+		return unpack(result)
+	end
+	function hooks:reset()
+		self._counter = nil
+		counter = {0}
+		self:enable()
+		self:restore()
+	end
+	function hooks:enable()
+		-- Enables call(), get(), push() and pop() without updating current state
+		if self._call then
+			self._call, self._get, self._push, self._pop, self.call,  self.get,  self.push,  self.pop
+			= nil,      nil,       nil,        nil,       self._call, self._get, self._push, self._pop
+			return true
+		end
+	end
+	function hooks:disable()
+		-- Disables call(), get(), push() and pop() without updating current state
+		if self._call == nil then
+			self._call,   self._get, self._push, self._pop, self.call, self.get,  self.push, self.pop
+			= self.call,  self.get,  self.push,  self.pop,  self.pass, self.pass, self.noop, self.noop
+			return true
+		end
+	end
+	hooks:disable()
+end
+
 local function load_luacov()
 	local luacov_defaults = require("luacov.defaults")
 	local luacov_config = {}
 	for k,v in pairs(luacov_defaults) do luacov_config[k] = v end
 	for k,v in pairs(args.luacov) do luacov_config[k] = v end
 
-	local luacov = require("luacov.runner")
-	luacov(luacov_config)
-	luacov.configuration = luacov_config
+	local runner = require("luacov.runner")
+	runner.load_config(luacov_config)
+	runner(luacov_config)
+	runner.configuration = luacov_config
+	assert(debug.gethook())
+	mineunit.debughooks:delete()
+	return runner
 end
 
 local busted = require("busted.core")()
@@ -573,11 +696,6 @@ local outputHandlerLoader = require("busted.modules.output_handler_loader")()
 
 require("busted")(busted)
 local exit = require("busted.compatibility").exit
-
-mineunit = {
-	mineunit_conf_defaults = mineunit_conf_defaults,
-	mineunit_conf_override = mineunit_conf_override,
-}
 
 -- Mineunit event subscriptions
 local internal_subs = {
@@ -609,8 +727,27 @@ function mineunit:subscribe(what, callback)
 end
 
 internal_subscribe("file_start", function()
+	-- Reset debug hooks
+	mineunit.debughooks:delete()
+	mineunit.debughooks:disable()
 	-- Remove all subscriptions before starting new test set
 	for k, _ in pairs(subs) do subs[k] = {} end
+end)
+
+internal_subscribe("file_end", function()
+	-- Remove debug hooks
+	mineunit.debughooks:delete()
+	mineunit.debughooks:disable()
+end)
+
+internal_subscribe("describe_start", function()
+	-- Reset debug hooks
+	mineunit.debughooks:reset()
+end)
+
+internal_subscribe("test_start", function()
+	-- Reset debug hooks
+	mineunit.debughooks:reset()
 end)
 
 busted.subscribe({'file', 'start'}, function(...) run_subs("file_start", ...) end)
@@ -623,8 +760,9 @@ busted.subscribe({'test', 'end'}, function(...) run_subs("test_end", ...) end)
 require("mineunit.print")
 busted.export('mineunit', mineunit)
 
+local luacov_runner
 if args.coverage then
-	load_luacov()
+	luacov_runner = load_luacov()
 end
 
 -- subscribe for additional output
@@ -788,7 +926,8 @@ execute(args.runs, {
 busted.publish({ 'exit' })
 
 if args.coverage then
-	require("luacov.runner").shutdown()
+	luacov_runner.shutdown()
+	--require("luacov.runner").shutdown()
 end
 
 if failures > 0 or errors > 0 then

--- a/config.lua
+++ b/config.lua
@@ -16,7 +16,7 @@ local default_config = {
 	engine_version = "mineunit",
 	deprecated = "throw",
 	deprecated_mineunit = "error",
-	singleplayer = true
+	singleplayer = false
 }
 
 local mineunit_conf_override = rawget(mineunit, "mineunit_conf_override") or {}

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,157 @@
+local pl_path = require('pl.path')
+local sequential = mineunit.utils.sequential
+
+local default_config = {
+	verbose = 2,
+	print = true,
+	modname = "mineunit",
+	root = ".",
+	mineunit_path = debug.getinfo(1).source:match("@?(.*)/"),
+	spec_path = "spec",
+	fixture_paths = {
+		"spec/fixtures"
+	},
+	source_path = ".",
+	time_step = -1,
+	engine_version = "mineunit",
+	deprecated = "throw",
+	deprecated_mineunit = "error",
+	singleplayer = true
+}
+
+local mineunit_conf_override = rawget(mineunit, "mineunit_conf_override") or {}
+for k,v in pairs(rawget(mineunit, "mineunit_conf_defaults") or {}) do
+	default_config[k] = v
+end
+rawset(mineunit, "mineunit_conf_defaults", nil)
+
+mineunit._config = {
+	modpaths = {},
+}
+
+function mineunit:config(key)
+	if self._config[key] ~= nil then
+		return self._config[key]
+	end
+	return default_config[key]
+end
+
+mineunit._config.source_path = pl_path.normpath(
+	("%s/%s"):format(mineunit:config("root"), mineunit:config("source_path"))
+)
+
+function mineunit:config_set(key, value)
+	self:debugf("Updating configuration '%s' from '%s' to '%s'", key, self._config[key], value)
+	self._config[key] = value
+end
+
+local function spec_path(name)
+	local path = pl_path.normpath(("%s/%s/%s"):format(mineunit:config("root"), mineunit:config("spec_path"), name))
+	if pl_path.isfile(path) then
+		mineunit:debugf("spec_path('%s') -> '%s'", name, path)
+		return path
+	end
+	mineunit:debugf("spec_path, file not found: '%s'", path)
+end
+
+local function deep_merge(data, target, defaults)
+	if sequential(data) and #data > 0 then
+		assert(sequential(defaults), "Configuration: attempt to merge indexed table with hash table")
+		-- Indexed arrays merge strategy: discard keys, add unique values
+		local seen = {}
+		for _,value in ipairs(defaults) do
+			table.insert(target, value)
+			seen[value] = true
+		end
+		for _,value in ipairs(data) do
+			assert(type(value) ~= "table", "Configuration: tables not supported in indexed arrays")
+			if not seen[value] then
+				table.insert(target, value)
+				mineunit:debugf("\t%d\t=\t'%s'", #target, value)
+			else
+				mineunit:debugf("\tSkipping duplicate value: %s", value)
+			end
+		end
+	else
+		-- Hash tables merge strategy: preserve keys, override values
+		for key,value in pairs(data) do
+			if defaults[key] then
+				assert(type(value) == type(defaults[key]), "Configuration: invalid data type for key", key)
+				if type(value) == "table" then
+					target[key] = {}
+					mineunit:debugf("Configuration: merging indexed array at '%s'", key)
+					deep_merge(value, target[key], defaults[key])
+				else
+					target[key] = value
+				end
+				mineunit:debugf("Configuration: '%s' = '%s'", key, value)
+			elseif key ~= "exclude" then
+				-- Excluding "exclude" is hack and on todo list, mineunit cli runner uses this configuration key
+				mineunit:warningf("Configuration: invalid key '%s'", key)
+			end
+		end
+	end
+end
+
+do -- Read mineunit config file
+	local configpath = spec_path("mineunit.conf")
+	if not configpath then
+		mineunit:infof("configpath, file not found: '%s'", configpath)
+	end
+	if configpath then
+		local configfile, err = mineunit.loadfile(configpath)
+		if configfile then
+			local configenv = {}
+			setfenv(configfile, configenv)
+			configfile()
+			deep_merge(configenv, mineunit._config, default_config)
+			-- Override config
+			if mineunit_conf_override then
+				for k, v in pairs(mineunit_conf_override) do
+					mineunit._config[k] = v
+				end
+			end
+			mineunit:infof("Mineunit configuration loaded from '%s'", configpath)
+		else
+			mineunit:warningf("Mineunit configuration failed: %s", err)
+		end
+	else
+		mineunit:warning("Mineunit configuration file not found")
+	end
+end
+
+local function source_path(name)
+	local cfg_source_path = mineunit:config("source_path")
+	local path = pl_path.normpath(("%s/%s"):format(cfg_source_path, name))
+	mineunit:debugf("source_path('%s') -> '%s'", name, path)
+	return path
+end
+
+-- Read mod.conf config file
+local function read_mod_config()
+	local modconfpath = source_path("mod.conf")
+	if not modconfpath then
+		mineunit:infof("mod.conf not found: '%s'", modconfpath)
+		return
+	end
+	local configfile = io.open(modconfpath, "r")
+	if configfile then
+		for line in configfile:lines() do
+			local key, value = string.gmatch(line, "([^=%s]+)%s*=%s*(.-)%s*$")()
+			if key == "name" then
+				if mineunit._config["modname"] then
+					mineunit:warning("Mod name defined in both mod.conf and mineunit.conf, using mineunit.conf")
+				else
+					mineunit._config["modname"] = value
+				end
+			end
+		end
+		mineunit:infof("Mod configuration loaded from '%s'", modconfpath)
+	else
+		mineunit:warning("Loading file mod.conf failed")
+	end
+end
+read_mod_config()
+
+-- Save original modname and set modpath
+mineunit._config["original_modname"] = mineunit:config("modname")

--- a/config.lua
+++ b/config.lua
@@ -75,7 +75,7 @@ local function deep_merge(data, target, defaults)
 	else
 		-- Hash tables merge strategy: preserve keys, override values
 		for key,value in pairs(data) do
-			if defaults[key] then
+			if defaults[key] ~= nil then
 				assert(type(value) == type(defaults[key]), "Configuration: invalid data type for key", key)
 				if type(value) == "table" then
 					target[key] = {}

--- a/core.lua
+++ b/core.lua
@@ -3,57 +3,46 @@ local noop_object = {
 	__call = function(self) return self end,
 	__index = function() return noop end,
 }
-local engine_version = mineunit:config("engine_version")
-local engine_version_minor = tonumber(engine_version:sub(3,3)) or -1
+
+local _, engine_version_minor = mineunit.utils.explode_version(mineunit:config("engine_version"), -1)
 
 mineunit("craft")
 mineunit("world")
-
-_G.core.notify_authentication_modified = noop
 
 _G.core.set_node = world.set_node
 _G.core.add_node = world.set_node
 _G.core.swap_node = world.swap_node
 
-_G.core.get_translator = function(...) return function(...) mineunit:debug(...) end end
-_G.core.set_http_api_lua = noop
-_G.core.inventorycube = function(img1, img2, img3)
-	img2 = img2 or img1
-	img3 = img3 or img1
-	return "[inventorycube"
-			.. "{" .. img1:gsub("%^", "&")
-			.. "{" .. img2:gsub("%^", "&")
-			.. "{" .. img3:gsub("%^", "&")
-end
 _G.minetest = _G.core
 
 mineunit("settings")
 _G.core.settings = _G.Settings(fixture_path("minetest.conf"))
 mineunit:apply_default_settings(_G.core.settings)
 
-_G.core.register_on_joinplayer = noop
-_G.core.register_on_leaveplayer = noop
-
-_G.core.register_on_player_receive_fields = noop
-
-mineunit("game/constants")
-mineunit("common/vector")
-mineunit("game/item")
-if engine_version_minor > 5 then
-	mineunit("game/misc_s")
-end
-mineunit("game/misc")
-mineunit("game/register")
-mineunit("common/misc_helpers")
-mineunit("game/privileges")
-mineunit("game/features")
-mineunit("common/serialize")
 mineunit("fs")
+if engine_version_minor > 5 then
+	mineunit("./init", { strict = true })
+else
+	mineunit("game/constants")
+	mineunit("common/vector")
+	mineunit("game/item")
+	mineunit("game/misc")
+	mineunit("game/register")
+	mineunit("common/misc_helpers")
+	mineunit("game/privileges")
+	mineunit("game/features")
+	mineunit("common/serialize")
+end
+
+_G.core.get_translator = function(...) return function(...) mineunit:debug(...) end end
 
 assert(core.registered_nodes["air"])
 assert(core.registered_nodes["ignore"])
 assert(core.registered_items[""])
 assert(core.registered_items["unknown"])
+
+function core.send_join_message(...) mineunit:info("Player joined:", ...) end
+function core.send_leave_message(...) mineunit:info("Player left:", ...) end
 
 mineunit("metadata")
 mineunit("itemstack")
@@ -103,52 +92,21 @@ _G.core.remove_detached_inventory = function(name)
 	return false
 end
 
-_G.core.sound_play = noop
-_G.core.sound_stop = noop
-_G.core.sound_fade = noop
-_G.core.add_particlespawner = noop
-
-_G.core.registered_chatcommands = {}
-_G.core.register_chatcommand = noop
+_G.core.registered_chatcommands = core.registered_chatcommands or {}
 _G.core.chat_send_player = function(...) print(unpack({...})) end
 _G.core.chat_send_all = function(...) print(unpack({...})) end
-_G.core.register_on_placenode = noop
-_G.core.register_on_dignode = noop
-_G.core.register_on_mods_loaded = function(func) mineunit:register_on_mods_loaded(func) end
 
-_G.core.item_drop = noop
-_G.core.add_item = noop
-_G.core.check_for_falling = noop
-_G.core.get_objects_inside_radius = function(...) return {} end
+_G.core.get_objects_inside_radius = function() return {} end
+_G.core.objects_inside_radius = function() return noop end -- 5.9.0
+_G.core.get_objects_in_area = function() return {} end
+_G.core.objects_in_area = function() return noop end -- 5.9.0
 
 _G.core.register_biome = noop
-_G.core.clear_registered_biomes = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
+_G.core.clear_registered_biomes = function() error("MINEUNIT UNSUPPORTED CORE METHOD") end
 _G.core.register_ore = noop
-_G.core.clear_registered_ores = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
+_G.core.clear_registered_ores = function() error("MINEUNIT UNSUPPORTED CORE METHOD") end
 _G.core.register_decoration = noop
-_G.core.clear_registered_decorations = function(...) error("MINEUNIT UNSUPPORTED CORE METHOD") end
-
-do
-	local time_step = tonumber(mineunit:config("time_step"))
-	assert(time_step, "Invalid configuration value for time_step. Number expected.")
-	if time_step < 0 then
-		mineunit:info("Running default core.get_us_time using real world wall clock.")
-		_G.core.get_us_time = function()
-			local socket = require 'socket'
-			-- FIXME: Returns the time in seconds, relative to the origin of the universe.
-			return socket.gettime() * 1000 * 1000
-		end
-	else
-		mineunit:info("Running custom core.get_us_time with step increment: "..tostring(time_step))
-		local time_now = 0
-		_G.core.get_us_time = function()
-			time_now = time_now + time_step
-			return time_now
-		end
-	end
-end
-
-_G.core.after = noop
+_G.core.clear_registered_decorations = function() error("MINEUNIT UNSUPPORTED CORE METHOD") end
 
 _G.core.find_nodes_with_meta = _G.world.find_nodes_with_meta
 _G.core.find_nodes_in_area = _G.world.find_nodes_in_area
@@ -156,29 +114,9 @@ _G.core.get_node_or_nil = _G.world.get_node
 _G.core.get_node = function(pos) return core.get_node_or_nil(pos) or {name="ignore",param1=0,param2=0} end
 _G.core.dig_node = function(pos) return world.on_dig(pos) and true or false end
 _G.core.remove_node = _G.world.remove_node
-_G.core.load_area = noop
 
 _G.core.get_node_timer = {}
 setmetatable(_G.core.get_node_timer, noop_object)
-
-local content_name2id = {}
-local content_id2name = {}
-_G.core.get_content_id = function(name)
-	-- check if the node exists
-	assert(core.registered_nodes[name], "node " .. name .. " is not registered")
-
-	-- create and increment
-	if not content_name2id[name] then
-		content_name2id[name] = #content_id2name
-		table.insert(content_id2name, name)
-	end
-	return content_name2id[name]
-end
-
-_G.core.get_name_from_content_id = function(cid)
-	assert(content_id2name[cid+1], "Unknown content id")
-	return content_id2name[cid+1]
-end
 
 --
 -- Minetest default noop table

--- a/core.lua
+++ b/core.lua
@@ -34,7 +34,12 @@ else
 	mineunit("common/serialize")
 end
 
-_G.core.get_translator = function(...) return function(...) mineunit:debug(...) end end
+_G.core.get_translator = function(...)
+	return function(...)
+		mineunit:debug(...)
+		return table.concat({...}, " ")
+	end
+end
 
 assert(core.registered_nodes["air"])
 assert(core.registered_nodes["ignore"])

--- a/craft.lua
+++ b/craft.lua
@@ -1,9 +1,10 @@
-
+local hooks = mineunit.debughooks
 local CM = mineunit('craftmanager')
 
 mineunit.CraftManager = CM
 
 function core.get_all_craft_recipes(output)
+	hooks:pop()
 	assert.is_string(output, "core.get_all_craft_recipes(output): invalid output type, expected string")
 	local results = {}
 	for method, allcrafts in pairs(CM.registered_crafts) do
@@ -23,6 +24,7 @@ function core.get_all_craft_recipes(output)
 			end
 		end
 	end
+	hooks:push()
 	return #results > 0 and results or nil
 end
 
@@ -114,9 +116,11 @@ end
 
 
 function core.register_craft(t)
+	hooks:pop()
 	assert.is_table(t, "core.register_craft: table expected, got %s")
 	t.type = t.type or "shaped"
 	assert.is_function(fn_register[t.type], "Recipe type not supported: " .. tostring(t.type))(t)
+	hooks:push()
 end
 
 function core.clear_craft(t)
@@ -148,6 +152,7 @@ local function items_empty(t)
 end
 
 function core.get_craft_result(t)
+	hooks:pop()
 	assert.is_hashed(t, "core.get_craft_result: hash table expected, got %s")
 	if t.method ~= nil then
 		assert.in_array(t.method, {"normal","cooking","fuel"}, "core.get_craft_result: t.method invalid value")
@@ -178,5 +183,6 @@ function core.get_craft_result(t)
 		items = input.items,
 	}
 
+	hooks:push()
 	return result, leftover
 end

--- a/deprecation.lua
+++ b/deprecation.lua
@@ -1,30 +1,29 @@
 return function(DEPRECATED)
---luacheck:push globals mineunit
-function mineunit.registered_craft_recipe(output, method)
-	DEPRECATED("Using deprecated function 'mineunit.registered_craft_recipe'")
-	return mineunit('craftmanager'):registered_craft_recipe(output, method)
-end
---luacheck:pop
-
---luacheck:push globals timeit
-function timeit(count, func, ...)
-	DEPRECATED("Using deprecated global function 'timeit', don't use it.")
-	local socket = require 'socket'
-	local t1 = socket.gettime() * 1000
-	for i=0,count do
-		func(...)
+	--luacheck:push globals mineunit
+	function mineunit.registered_craft_recipe(output, method)
+		DEPRECATED("Using deprecated function 'mineunit.registered_craft_recipe'")
+		return mineunit('craftmanager'):registered_craft_recipe(output, method)
 	end
-	local diff = (socket.gettime() * 1000) - t1
-	local info = debug.getinfo(func,'S')
-	mineunit:info(("\nTimeit: %s:%d took %d ticks"):format(info.short_src, info.linedefined, diff))
-	return diff, info
-end
---luacheck:pop
+	--luacheck:pop
 
---luacheck:push globals count
-function count(...)
-	DEPRECATED("Using deprecated global function 'count', use 'mineunit.utils.count' instead.")
-	return mineunit.utils.count(...)
-end
---luacheck:pop
+	--luacheck:push globals timeit
+	function timeit(count, func, ...)
+		DEPRECATED("Using deprecated global function 'timeit', don't use it.")
+		local t1 = os.clock() * 1000
+		for i=0,count do
+			func(...)
+		end
+		local diff = (os.clock() * 1000) - t1
+		local info = debug.getinfo(func,'S')
+		mineunit:info(("\nTimeit: %s:%d took %d ticks"):format(info.short_src, info.linedefined, diff))
+		return diff, info
+	end
+	--luacheck:pop
+
+	--luacheck:push globals count
+	function count(...)
+		DEPRECATED("Using deprecated global function 'count', use 'mineunit.utils.count' instead.")
+		return mineunit.utils.count(...)
+	end
+	--luacheck:pop
 end

--- a/entity.lua
+++ b/entity.lua
@@ -1,5 +1,10 @@
 mineunit("common/vector")
 
+local function assert_range(value, minimum, maximum)
+	assert(type(value) == "number" and value >= minimum and value <= maximum, "assert_range: invalid value")
+	return value
+end
+
 local ObjectRef = {}
 
 function ObjectRef:set_velocity(value) self._velocity = vector.new(value) end
@@ -11,12 +16,10 @@ function ObjectRef:get_pitch() return self._pitch end
 function ObjectRef:set_pitch(value) self._pitch = value end
 function ObjectRef:get_roll() return self._roll end
 function ObjectRef:set_roll(value) self._roll = value end
-
-
-
 function ObjectRef:get_pos() return table.copy(self._pos) end
 function ObjectRef:set_pos(value) self._pos = vector.new(value) end
 function ObjectRef:get_velocity() return table.copy(self._velocity) end
+
 function ObjectRef:add_velocity(vel)
 	-- * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
 	-- * In comparison to using get_velocity, adding the velocity and then using
@@ -44,16 +47,8 @@ end
 function ObjectRef:right_click(clicker)
 	--; `clicker` is another `ObjectRef`
 end
-function ObjectRef:get_hp()
-	--: returns number of health points
-end
-function ObjectRef:set_hp(hp, reason)
-	--: set number of health points
-	-- * See reason in register_on_player_hpchange
-	-- * Is limited to the range of 0 ... 65535 (2^16 - 1)
-	-- * For players: HP are also limited by `hp_max` specified in the player's
-	--   object properties
-end
+function ObjectRef:get_hp() return self._hp end
+function ObjectRef:set_hp(hp) self._hp = assert_range(hp, 0, 65535) end
 function ObjectRef:get_inventory()
 	--: returns an `InvRef` for players, otherwise returns `nil`
 end

--- a/entity.lua
+++ b/entity.lua
@@ -71,12 +71,8 @@ function ObjectRef:set_wielded_item(item)
 	--: replaces the wielded item, returns `true` if
 	-- successful.
 end
-function ObjectRef:set_armor_groups(t)
-	-- {group1=rating, group2=rating, ...}
-end
-function ObjectRef:get_armor_groups()
-	--: returns a table with the armor group ratings
-end
+function ObjectRef:set_armor_groups(t) self._armor_groups = t end
+function ObjectRef:get_armor_groups() return table.copy(self._armor_groups) end
 function ObjectRef:set_animation(frame_range, frame_speed, frame_blend, frame_loop)
 	-- * `frame_range`: table {x=num, y=num}, default: `{x=1, y=1}`
 	-- * `frame_speed`: number, default: `15.0`
@@ -155,6 +151,7 @@ mineunit.export_object(ObjectRef, {
 			_pitch = 0,
 			_roll = 0,
 			_properties = {},
+			_armor_groups = {},
 		}
 		setmetatable(obj, ObjectRef)
 		return obj

--- a/formspec.lua
+++ b/formspec.lua
@@ -1,0 +1,387 @@
+local Form = {}
+
+-- Split but with iterator and handle backslash escapes
+local function esplit(s, c)
+	local i = 1;
+	return function()
+		local b = i
+		local e = s:find(c, i, true)
+		while e do
+			if s:sub(e - 1, e - 1) ~= "\\" then
+				i = e + 1
+				return s:sub(b, e - 1)
+			end
+			i = i + e
+			e = s:find(c, i, true)
+		end
+		if i < #s then
+			b, i = i, #s
+			return s:sub(b)
+		end
+	end
+end
+
+-- Process certain well known element definition values
+local function process_value(index, value)
+	if index < 3 then
+		local num = esplit(value, ",")
+		return {tonumber(num() or nil), tonumber(num() or nil)}
+	elseif  index > 5 then
+		-- FIXME: Also process not so well known values... probably very wrong
+		return value:split(",")
+	end
+	return value
+end
+
+-- Like ipairs but just value without index
+local function ivalues(t)
+	local index, max = 0, #t
+	return function()
+		index = index + 1
+		if index <= max then
+			return t[index]
+		end
+	end
+end
+
+-- Swap and process things, see fs_elements below
+local function swapper(...)
+	local args = {...}
+	return function(input)
+		local iterator, result
+		if type(input) == "string" then
+			-- create new table when input is string
+			iterator, result = esplit(input, ";"), {}
+		else
+			-- process in place when input is table
+			iterator, result = ivalues(input), input
+		end
+		local i = 1
+		for value in iterator do
+			while args[i] == 0 do
+				table.insert(result, false)
+				i = i + 1
+			end
+			local index = args[i] or i
+			result[index] = process_value(index, value)
+			i = i + 1
+		end
+		return result
+	end
+end
+
+-- Elements to parse, for unlisted/commented only type names will be added and parameters are completely skipped.
+-- Output fields: x/y, w/h, name, value, tbd
+-- After exhausting arguments, swapper continues in order. This means that contiguous indexes can be omitted.
+-- TODO: Allow negative (backwards) indices for swapper.
+local fs_elements = {
+	--container = 1,
+	--container_end = 1,
+	--list = 1,
+	--listring = 1,
+	checkbox = swapper(1, 0, 2, 4, 3),
+	--image = 1,
+	--animated_image = 1,
+	--item_image = 1,
+	button = swapper(),
+	button_exit = swapper(),
+	button_url = swapper(),
+	button_url_exit = swapper(),
+	--background = 1,
+	--background9 = 1,
+	--tableoptions = 1,
+	--tablecolumns = 1,
+	--table = 1,
+	textlist = swapper(),
+	dropdown = swapper(),
+	--field_enter_after_edit = 1,
+	--field_close_on_enter = 1,
+	pwdfield = swapper(),
+	field = (function()
+		local s1 = swapper(1, 2, 3, 5, 4)
+		local s2 = swapper(0, 0, 1, 3, 2)
+		return function(s)
+			local t = s:split(";")
+			return #t > 3 and s1(t) or s2(t)
+		end
+	end)(),
+	textarea = swapper(1, 2, 3, 5, 4),
+	--hypertext = 1,
+	--label = 1,
+	--vertlabel = 1,
+	item_image_button = swapper(1, 2, 5, 3, 4),
+	image_button = swapper(1, 2, 5, 3, 4),
+	image_button_exit = swapper(1, 2, 5, 3, 4),
+	--tabheader = 1,
+	--box = 1,
+	--bgcolor = 1,
+	--listcolors = 1,
+	--tooltip = 1,
+	--scrollbar = 1,
+	--real_coordinates = 1,
+	--style = 1,
+	--style_type = 1,
+	--scrollbaroptions = 1,
+	--scroll_container = 1,
+	--scroll_container_end = 1,
+	--set_focus = 1,
+	--model = 1,
+}
+
+local Element = {}
+Element.__index = Element
+
+function Element:type()
+	return assert(self._type)
+end
+
+function Element:pos()
+	return self._data[1] or {}
+end
+
+function Element:size()
+	return  self._data[2] or {}
+end
+
+function Element:name()
+	return self._data[3] or ""
+end
+
+function Element:value(data)
+	if data ~= nil then
+		assert.is_string(data, "Form: Element:value(data) unexpected data, expected string but got "..type(data))
+		self._data[4] = data
+	end
+	return self._data[4] or ""
+end
+
+function Element:__tostring()
+	return ("Element<%s>(%s, %s)"):format(self:type(), self:name(), self:value())
+end
+
+-- Parse formspec and return parsed form elements.
+local function parse(formspec)
+	local results = {}
+	for es in esplit(formspec, "]") do
+		local i = es:find("[", 1, true)
+		local element = setmetatable({ _type = es:sub(1, i - 1) }, Element)
+		if fs_elements[element._type] then
+			table.insert(results, element)
+			results[#results]._data = fs_elements[element._type](es:sub(i + 1))
+		--else
+		--	results[#results]._data = es:sub(i + 1):trim()
+		end
+	end
+	return results
+end
+
+-- Find form elements based on name and/or type patterns. Returns iterator.
+function Form:find(namepattern, typepattern)
+	local index = 0
+	if namepattern and typepattern then
+		-- Match both typepattern and namepattern
+		return function()
+			while index < #self._data do
+				index = index + 1
+				local e = self._data[index]
+				if e:type():find(typepattern) and e:name():find(namepattern) then
+					return e
+				end
+			end
+		end
+	elseif namepattern then
+		-- Match only namepattern
+		return function()
+			while index < #self._data do
+				index = index + 1
+				local e = self._data[index]
+				if e:name():find(namepattern) then
+					return e
+				end
+			end
+		end
+	elseif typepattern then
+		-- Match only typepattern
+		return function()
+			while index < #self._data do
+				index = index + 1
+				local e = self._data[index]
+				if e:type():find(typepattern) then
+					return e
+				end
+			end
+		end
+	else
+		error("Invalid arguments Form:find(<falsy>, <falsy>)")
+	end
+end
+
+-- Get first matching form element
+function Form:one(namepattern, typepattern)
+	return self:find(namepattern, typepattern)()
+end
+
+-- Get all matching form elements
+function Form:all(namepattern, typepattern)
+	local results = {}
+	for e in self:find(namepattern, typepattern) do
+		table.insert(results, e)
+	end
+	return results
+end
+
+local submit_fields = {
+	animated_image = 1, -- Returns the index of the current frame.
+	button = 1, -- button and variants contains the button text as value. If not pressed, is `nil`.
+	image_button = 1,
+	item_image_button = 1,
+	button_exit = 1,
+	image_button_exit = 1,
+	button_url = 1,
+	button_url_exit = 1,
+
+	pwdfield = 1, -- field, textarea and variants contains text in the field.
+	field = 1,
+	--field_enter_after_edit = 1, -- Experimental
+	--field_close_on_enter = 1, -- If false, pressing Enter in field submits form without closing. Default true.
+	textarea = 1,
+	--hypertext = 1, -- Unstable + check spec
+
+	dropdown = 1, -- Either the index or value, depending on the `index event` dropdown argument.
+	tabheader = 1, -- Tab index, starting with `"1"` (only if tab changed).
+	checkbox = 1, -- "true" if checked, "false" if unchecked.
+	textlist = 1, -- See `core.explode_textlist_event`.
+	table = 1, -- See `core.explode_table_event`.
+	scrollbar = 1, -- See `core.explode_scrollbar_event`.
+	-- quit = "true" if user closed the form by mouse click, keypress or through a button_exit[] element.
+	-- key_enter = "true"` if user pressed Enter and focus was nowhere (formspec closed) or on a button.
+	--   If text field was focused, `key_enter_field` contains the name of the field. See: `field_close_on_enter`
+}
+
+-- Get fields that would be submitted with any of the basic submit actions.
+-- TODO: Allow specifying trigger, like button or scrollbar for example, and return fields based on action.
+-- FIXME: Currently results will be wrong: includes everything like buttons that shouldn't be there.
+function Form:fields()
+	mineunit:error("Form:fields() is experimental and UNSTABLE. Its behavior and interface WILL BE CHANGED.")
+	local results = {}
+	for e in ivalues(self._data) do
+		if submit_fields[e:type()] and e:name() ~= "" then
+			results[e:name()] = e:value()
+		end
+	end
+	return results
+end
+
+-- Get or set form field value by field name, will not edit formspec text content
+function Form:value(name, data)
+	local e = self:one("^"..name.."$", nil)
+	mineunit:debugf("Form:value(%s, %s) Field: %s", name, data, e)
+	if e then
+		return e:value(data)
+	end
+	mineunit:errorf("Form<%s>:value(%s, %s) failed, could nto find valid element.", self._name, name, data)
+end
+
+function Form:data()
+	return self._data
+end
+
+function Form:text()
+	return self._textcontent
+end
+
+function Form:name()
+	return self._name
+end
+
+function Form:version()
+	error("Not implemented: Form:version()")
+end
+
+function Form:__index(key)
+	local value = rawget(Form, key)
+	if value ~= nil then
+		return value
+	end
+	value = rawget(self, key)
+	if value ~= nil then
+		return value
+	elseif key == "_data" then
+		rawset(self, "_data", parse(rawget(self, "_textcontent")))
+		return rawget(self, "_data")
+	end
+end
+
+function Form:__tostring()
+	return self._textcontent
+end
+
+-- Mixed instance/static utility functions, last argument is fields, second to last is player
+function Form:send(...)
+	local args = {...}
+	local form, player, fields
+	if mineunit.utils.type(self) == "Form" then
+		-- Instance method, send this form to player
+		form, player, fields = self, args[1], args[2]
+	else
+		-- Static method, get instance and send it
+		player, fields = self, args[1]
+	end
+	assert.player_or_name(player, "mineunit:get_player_formspec: player_or_name: expected string or Player")
+	player = type(player) == "string" and mineunit:get_players()[player] or player
+	if not form then
+		-- Should only end up here if called with Form.send(player, fields) instead of form:send(player[, fields])
+		form = player._formspec
+	end
+	if fields then
+		return mineunit:execute_on_player_receive_fields(player, form:name(), fields)
+	else
+		return mineunit:execute_on_player_receive_fields(player, form:name(), form:fields())
+	end
+end
+
+function mineunit:send_formspec_fields(player_or_name, fields)
+	assert.player_or_name(player_or_name, "mineunit:get_player_formspec: player_or_name: expected string or Player")
+	local player = type(player_or_name) == "string" and self:get_players()[player_or_name] or player_or_name
+	assert(player._formspec, "mineunit.send_formspec_fields: no formspec open")
+	local ftype = type(fields)
+	assert.in_array(ftype, {"nil","table"}, "mineunit:send_formspec_fields: fields: expected table or nil, got "..ftype)
+	return self:Form().send(player, fields)
+end
+
+function mineunit:set_formspec_fields(player_or_name, fields)
+	assert.player_or_name(player_or_name, "mineunit:get_player_formspec: player_or_name: expected string or Player")
+	local player = type(player_or_name) == "string" and self:get_players()[player_or_name] or player_or_name
+	assert(player._formspec, "mineunit.send_formspec_fields: no formspec open")
+	assert(player._formname, "mineunit.set_formspec_fields: no formspec open")
+	local form = player._formspec
+	for k, v in pairs(fields) do
+		form:value(k, v)
+	end
+end
+
+function mineunit:set_formspec_field(player_or_name, key, value)
+	return self:set_formspec_fields(player_or_name, {key = value})
+end
+
+-- Register private class, exposed through mineunit
+mineunit.export_object(Form, {
+	name = "Form",
+	private = true,
+	constructor = function(self, formname, formspec)
+		mineunit:debugf("Form(%s, ...) -> new form.", formname)
+		local obj = {
+			_name = formname,
+			_version = nil,
+			_data = nil, -- deferrend _textcontent parsing
+			_textcontent = formspec,
+		}
+		setmetatable(obj, Form)
+		return obj
+	end,
+})
+
+function mineunit:Form(formname, formspec)
+	-- For this method, `self` can be either Mineunit or Player instance
+	return formname and Form(formname, formspec) or Form
+end

--- a/globals.lua
+++ b/globals.lua
@@ -1,19 +1,14 @@
--- Globals defined by Minetest
---
--- For more information see following source files:
--- https://github.com/minetest/minetest/blob/master/src/script/cpp_api/s_base.cpp
--- https://github.com/minetest/minetest/blob/master/src/porting.h
-
 -- Load basic libraries and Mineunit assertions
 
 local assert = require('luassert.assert')
 mineunit.utils = require("mineunit.assert")
 local noop = mineunit.utils.noop
+local _, engine_version_minor = mineunit.utils.explode_version(mineunit:config("engine_version"), -1)
 
 -- Constants
 
 os.setlocale("C")
-INIT = "client"
+INIT = "game"
 PLATFORM = "Linux"
 DIR_DELIM = "/"
 
@@ -21,9 +16,29 @@ DIR_DELIM = "/"
 
 local core = {}
 
-core.register_item_raw = noop
-core.unregister_item_raw = noop
+core.add_item = noop
+core.add_particlespawner = noop
+core.after = noop
+core.check_for_falling = noop
+core.item_drop = noop
+core.load_area = noop
+core.notify_authentication_modified = noop
 core.register_alias_raw = noop
+core.register_chatcommand = noop
+core.register_on_dignode = noop
+core.register_on_joinplayer = noop
+core.register_on_leaveplayer = noop
+core.register_on_placenode = noop
+core.register_on_player_receive_fields = noop
+core.request_http_api = noop
+core.sound_fade = noop
+core.sound_play = noop
+core.sound_stop = noop
+core.unregister_item_raw = noop
+core.settings = setmetatable({}, {
+	__index = function() return function() end end,
+	__newindex = function() end,
+})
 
 function core.get_builtin_path()
 	local tag = mineunit:config("engine_version")
@@ -43,6 +58,10 @@ function core.get_current_modname(...)
 	return mineunit:get_current_modname(...)
 end
 
+function core.register_on_mods_loaded(func)
+	mineunit:register_on_mods_loaded(func)
+end
+
 function core.global_exists(name)
 	return rawget(_G, name) ~= nil
 end
@@ -59,9 +78,6 @@ function core.log(level, ...)
 	end
 end
 
--- http.lua implements actual usable HTTP API
-function core.request_http_api(...) end
-
 function core.gettext(value)
 	assert.is_string(value, "core.gettext: expected string, got " .. type(value))
 	return value
@@ -69,6 +85,25 @@ end
 
 function core.is_singleplayer()
 	return mineunit:config("singleplayer")
+end
+
+do
+	local time_step = tonumber(mineunit:config("time_step"))
+	assert(time_step, "Invalid configuration value for time_step. Number expected.")
+	if time_step < 0 then
+		mineunit:info("Running default core.get_us_time using real world wall clock.")
+		function core.get_us_time()
+			-- FIXME: Returns the time in seconds, relative to the origin of the universe.
+			return os.clock() * 1000 * 1000
+		end
+	else
+		mineunit:info("Running custom core.get_us_time with step increment: "..tostring(time_step))
+		local time_now = 0
+		function core.get_us_time()
+			time_now = time_now + time_step
+			return time_now
+		end
+	end
 end
 
 local core_timeofday = 0.5
@@ -85,6 +120,12 @@ end
 function core.get_node_light(pos, timeofday)
 	timeofday = timeofday or core.get_timeofday()
 	return mineunit.utils.round(math.sin(timeofday * 3.14) * 15)
+end
+
+function core.inventorycube(img1, img2, img3)
+	img2 = img2 or img1
+	img3 = img3 or img1
+	return "[inventorycube{" .. img1:gsub("%^", "&") .. "{" .. img2:gsub("%^", "&") .. "{" .. img3:gsub("%^", "&")
 end
 
 function core.compare_block_status(pos, status)
@@ -109,10 +150,79 @@ local origin
 function core.get_last_run_mod() return origin end
 function core.set_last_run_mod(v) origin = v end
 
+core.CONTENT_UNKNOWN = 125
+core.CONTENT_AIR = 126
+core.CONTENT_IGNORE = 127
+local content_name2id = {
+	unknown = core.CONTENT_UNKNOWN,
+	air = core.CONTENT_AIR,
+	ignore = core.CONTENT_IGNORE,
+}
+local content_id2name = {
+	[core.CONTENT_UNKNOWN] = "unknown",
+	[core.CONTENT_AIR] = "air",
+	[core.CONTENT_IGNORE] = "ignore",
+}
+
+function core.get_content_id(name)
+	-- Check if name is valid. Special case: unknown is always valid but item instead of node
+	assert(core.registered_nodes[name] or name == "unknown", "Node '" .. name .. "' is not registered")
+	return content_name2id[name]
+end
+
+function core.get_name_from_content_id(cid)
+	assert(content_id2name[cid], "Unknown content id " .. tostring(cid))
+	return content_id2name[cid]
+end
+
+function core.register_item_raw(def)
+	-- Create new content id for registered nodes
+	if def.type == "node" and not content_name2id[assert(def.name)] then
+		content_name2id[def.name] = #content_id2name + 1
+		table.insert(content_id2name, def.name)
+	end
+end
+
 -- Engine version compatibility
 
 -- 5.6.x releases had vector defined in engine
-_G.vector = { metatable = {} }
+if engine_version_minor == 6 then
+	_G.vector = { metatable = {} }
+end
+
+-- Since 5.5.x http_add_fetch been protected behind private engine set_http_api_lua
+if engine_version_minor > 4 then
+	function core.set_http_api_lua(fn)
+		rawset(core, "http_add_fetch", fn)
+	end
+end
+
+-- Since 5.7.x get_content_id uses caching, disable it
+if engine_version_minor > 6 then
+	local overrides = {}
+	local function override(key) overrides[key], core[key] = core[key], nil end
+	override("get_content_id")
+	override("get_name_from_content_id")
+
+	local CORE = {}
+
+	function CORE:__index(key)
+		if overrides[key] then
+			return overrides[key]
+		end
+		return rawget(core, key)
+	end
+
+	function CORE:__newindex(key, value)
+		if overrides[key] == nil then
+			rawset(core, key, value)
+		end
+	end
+
+	core.__index = CORE
+	setmetatable(core, CORE)
+end
+core.__metatable = "locked at globals.lua"
 
 -- Set engine core and its aliases
 

--- a/globals.lua
+++ b/globals.lua
@@ -85,6 +85,10 @@ function core.gettext(value)
 	return value
 end
 
+function core.get_server_status(name, joined)
+	return ""
+end
+
 function core.is_singleplayer()
 	return mineunit:config("singleplayer")
 end

--- a/globals.lua
+++ b/globals.lua
@@ -1,7 +1,7 @@
 -- Load basic libraries and Mineunit assertions
 
+local hooks = mineunit.debughooks
 local assert = require('luassert.assert')
-mineunit.utils = require("mineunit.assert")
 local noop = mineunit.utils.noop
 local _, engine_version_minor = mineunit.utils.explode_version(mineunit:config("engine_version"), -1)
 
@@ -67,6 +67,7 @@ function core.global_exists(name)
 end
 
 function core.log(level, ...)
+	hooks:pop()
 	if level == "error" then
 		mineunit:error(...)
 	elseif level == "warning" then
@@ -76,6 +77,7 @@ function core.log(level, ...)
 	else
 		mineunit:info(...)
 	end
+	hooks:push()
 end
 
 function core.gettext(value)
@@ -135,14 +137,18 @@ end
 local json = require('mineunit.lib.json')
 
 function core.write_json(...)
+	hooks:pop()
 	local args = {...}
 	local success, result = pcall(function() return json.encode(unpack(args)) end)
+	hooks:push()
 	return success and result or nil
 end
 
 function core.parse_json(...)
+	hooks:pop()
 	local args = {...}
 	local success, result = pcall(function() return json.decode(unpack(args)) end)
+	hooks:push()
 	return success and result or nil
 end
 

--- a/http.lua
+++ b/http.lua
@@ -100,7 +100,7 @@ setmetatable(MineunitHTTPServer, {
 mineunit.http_server = MineunitHTTPServer()
 
 --
--- Minetest HTTP API
+-- Engine HTTP API
 --
 
 local httpenv = {
@@ -114,7 +114,7 @@ local httpenv = {
 	end,
 }
 
--- Minetest core function to inject fetch method
+-- Engine function to inject fetch method
 core.http_add_fetch(httpenv)
 
 function core.request_http_api()

--- a/init.lua
+++ b/init.lua
@@ -1,49 +1,29 @@
--- FIXME: Sorry, not exactly nice in its current state
--- Have extra time and energy? Feel free to clean it a bit
-
-local pl = {
-	path = require 'pl.path',
-	--dir = require 'pl.dir',
-}
+local pl_path = require('pl.path')
 
 local lua_dofile = dofile
-function _G.dofile(path)
-	return lua_dofile(pl.path.normpath(path))
-end
-
 local lua_loadfile = loadfile
-function _G.loadfile(path, ...)
-	return lua_loadfile(pl.path.normpath(path), ...)
+if mineunit == nil then
+	mineunit = {}
+	function mineunit.dofile(path)
+		return lua_dofile(pl_path.normpath(path))
+	end
+	function mineunit.loadfile(path, ...)
+		return lua_loadfile(pl_path.normpath(path), ...)
+	end
+else
+	mineunit.dofile = lua_dofile
+	mineunit.loadfile = lua_loadfile
 end
+mineunit.__index = mineunit
 
-local default_config = {
-	verbose = 2,
-	print = true,
-	modname = "mineunit",
-	root = ".",
-	mineunit_path = debug.getinfo(1).source:match("@?(.*)/"),
-	spec_path = "spec",
-	fixture_paths = {
-		"spec/fixtures"
-	},
-	source_path = ".",
-	time_step = -1,
-	engine_version = "mineunit",
-	deprecated = "throw",
-	deprecated_mineunit = "error",
-	singleplayer = true
-}
+local assert = require('luassert.assert')
+mineunit.utils = require("mineunit.assert")
+require("mineunit.print")
+require("mineunit.config")
+require("mineunit.globals")
 
-mineunit = mineunit or {}
-local mineunit_conf_override = rawget(mineunit, "mineunit_conf_override") or {}
-for k,v in pairs(rawget(mineunit, "mineunit_conf_defaults") or {}) do
-	default_config[k] = v
-end
-rawset(mineunit, "mineunit_conf_defaults", nil)
+local hooks = mineunit.debughooks
 
-mineunit._config = {
-	modpaths = {},
-}
 mineunit._on_mods_loaded = {}
 mineunit._on_mods_loaded_exec_count = 0
 
@@ -61,14 +41,19 @@ local preload_modules = {
 	["game/auth"] = "auth",
 }
 
-require("mineunit.print")
-require("mineunit.globals")
+function _G.dofile(path)
+	return hooks:get(mineunit.dofile, path)
+end
+
+function _G.loadfile(path, ...)
+	return hooks:get(mineunit.loadfile, path, ...)
+end
 
 local _mineunits = {}
 local _subloader_preload
 
 local function require_filter(path, namepattern, loader, ...)
-	path = pl.path.normpath(path)
+	path = pl_path.normpath(path)
 	local name = path:gsub(namepattern, "%1")
 	if _mineunits[name] then
 		mineunit:debugf("Potential source of errors: reusing %s", name)
@@ -147,19 +132,21 @@ local function require_mineunit(name, root, tag, strict)
 	return require("mineunit." .. modulename)
 end
 
-mineunit.__index = mineunit
 setmetatable(mineunit, {
 	__call = function(self, name, options)
 		if name == _subloader_preload then
 			mineunit:debugf("Loader skipping queued module %s", name)
 			return
-		elseif _mineunits[name] == nil then
+		end
+		hooks:pop()
+		if _mineunits[name] == nil then
 			-- FIXME: hack to get around bad choices around module loader choices
 			local strict = options and options.strict
 			_mineunits[name] = {require_mineunit(
 				name, mineunit:config("core_root"), mineunit:config("engine_version"), strict
 			)}
 		end
+		hooks:push()
 		return unpack(_mineunits[name])
 	end,
 })
@@ -168,24 +155,8 @@ function mineunit:has_module(name)
 	return _mineunits[name] and true
 end
 
-function mineunit:config_set(key, value)
-	self:debugf("Updating configuration '%s' from '%s' to '%s'", key, self._config[key], value)
-	self._config[key] = value
-end
-
-function mineunit:config(key)
-	if self._config[key] ~= nil then
-		return self._config[key]
-	end
-	return default_config[key]
-end
-
-mineunit._config.source_path = pl.path.normpath(
-	("%s/%s"):format(mineunit:config("root"), mineunit:config("source_path"))
-)
-
 function mineunit:set_modpath(name, path)
-	path = pl.path.normpath(path)
+	path = pl_path.normpath(path)
 	mineunit:infof("Setting modpath of '%s' to '%s'", name, path)
 	self._config.modpaths[name] = path
 end
@@ -219,6 +190,7 @@ function mineunit:register_on_mods_loaded(func)
 end
 
 function mineunit:mods_loaded()
+	hooks:pop()
 	if self._on_mods_loaded then
 		mineunit:info("Executing register_on_mods_loaded functions")
 		if self._on_mods_loaded_exec_count > 0 then
@@ -238,18 +210,17 @@ function mineunit:mods_loaded()
 				end
 			end
 		end
-		for _,func in ipairs(self._on_mods_loaded) do func() end
+		-- Enable hooks so that push, pop, call and get are usable also outside describe blocks
+		local hooks_disabled = hooks:enable()
+		for _,func in ipairs(self._on_mods_loaded) do
+			hooks:call(func)
+		end
+		if hooks_disabled then
+			hooks:disable()
+		end
 		self._on_mods_loaded_exec_count = self._on_mods_loaded_exec_count + 1
 	end
-end
-
-local function spec_path(name)
-	local path = pl.path.normpath(("%s/%s/%s"):format(mineunit:config("root"), mineunit:config("spec_path"), name))
-	if pl.path.isfile(path) then
-		mineunit:debugf("spec_path('%s') -> '%s'", name, path)
-		return path
-	end
-	mineunit:debugf("spec_path, file not found: '%s'", path)
+	hooks:push()
 end
 
 function fixture_path(name)
@@ -262,36 +233,37 @@ function fixture_path(name)
 	local root = mineunit:config("root")
 	local search_paths = mineunit:config("fixture_paths")
 	for _,search_path in ipairs(search_paths) do
-		local path = pl.path.normpath(("%s/%s/%s"):format(root, search_path, name))
-		if pl.path.isfile(path) then
+		local path = pl_path.normpath(("%s/%s/%s"):format(root, search_path, name))
+		if pl_path.isfile(path) then
 			return path
 		else
 			mineunit:debugf("fixture_path, file not found: '%s'", path)
 		end
 	end
-	local path = pl.path.normpath(("%s/%s/%s"):format(root, search_paths[1], name))
+	local path = pl_path.normpath(("%s/%s/%s"):format(root, search_paths[1], name))
 	mineunit:infof("File not found: '%s'", path)
 	return path
 end
 
 local _fixtures = {}
 function fixture(name)
+	hooks:pop()
 	local path = fixture_path(name .. ".lua")
 	if not _fixtures[name] then
 		mineunit:infof("Loading fixture %s", path)
-		assert(pl.path.isfile(path), "Fixture not found: " .. path)
+		assert(pl_path.isfile(path), "Fixture not found: " .. path)
 		local result = {dofile(path)}
 		_fixtures[name] = result
-		return unpack(result)
 	else
 		mineunit:debugf("Fixture already loaded: %s", path)
-		return unpack(_fixtures[name])
 	end
+	hooks:push()
+	return unpack(_fixtures[name])
 end
 
 local function source_path(name)
 	local cfg_source_path = mineunit:config("source_path")
-	local path = pl.path.normpath(("%s/%s"):format(cfg_source_path, name))
+	local path = pl_path.normpath(("%s/%s"):format(cfg_source_path, name))
 	mineunit:debugf("source_path('%s') -> '%s'", name, path)
 	return path
 end
@@ -299,8 +271,13 @@ end
 function sourcefile(name)
 	local path = source_path(name .. ".lua")
 	mineunit:infof("Loading source %s", path)
-	assert(pl.path.isfile(path), "Source file not found: " .. path)
-	return dofile(path)
+	assert(pl_path.isfile(path), "Source file not found: " .. path)
+	local hooks_disabled = hooks:enable()
+	local module = {dofile(path)}
+	if hooks_disabled then
+		hooks:disable()
+	end
+	return unpack(module)
 end
 
 local function DEPRECATED(instance, action, msg)
@@ -328,8 +305,12 @@ function mineunit.export_object(obj, def)
 	end
 	setmetatable(obj, {
 		__call = function(...)
+			local hooks_enabled = hooks:delete()
 			local ins = def.constructor(...)
 			ins._mineunit_typename = def.typename or def.name
+			if hooks_enabled then
+				hooks:restore()
+			end
 			return ins
 		end
 	})
@@ -338,100 +319,7 @@ function mineunit.export_object(obj, def)
 	end
 end
 
-local sequential = mineunit.utils.sequential
-
-function mineunit.deep_merge(data, target, defaults)
-	if sequential(data) and #data > 0 then
-		assert(sequential(defaults), "Configuration: attempt to merge indexed table with hash table")
-		-- Indexed arrays merge strategy: discard keys, add unique values
-		local seen = {}
-		for _,value in ipairs(defaults) do
-			table.insert(target, value)
-			seen[value] = true
-		end
-		for _,value in ipairs(data) do
-			assert(type(value) ~= "table", "Configuration: tables not supported in indexed arrays")
-			if not seen[value] then
-				table.insert(target, value)
-				mineunit:debugf("\t%d\t=\t'%s'", #target, value)
-			else
-				mineunit:debugf("\tSkipping duplicate value: %s", value)
-			end
-		end
-	else
-		-- Hash tables merge strategy: preserve keys, override values
-		for key,value in pairs(data) do
-			if defaults[key] then
-				assert(type(value) == type(defaults[key]), "Configuration: invalid data type for key", key)
-				if type(value) == "table" then
-					target[key] = {}
-					mineunit:debugf("Configuration: merging indexed array at '%s'", key)
-					mineunit.deep_merge(value, target[key], defaults[key])
-				else
-					target[key] = value
-				end
-				mineunit:debugf("Configuration: '%s' = '%s'", key, value)
-			elseif key ~= "exclude" then
-				-- Excluding "exclude" is hack and on todo list, mineunit cli runner uses this configuration key
-				mineunit:warningf("Configuration: invalid key '%s'", key)
-			end
-		end
-	end
-end
-
-do -- Read mineunit config file
-	local configpath = spec_path("mineunit.conf")
-	if not configpath then
-		mineunit:infof("configpath, file not found: '%s'", configpath)
-	end
-	if configpath then
-		local configfile, err = loadfile(configpath)
-		if configfile then
-			local configenv = {}
-			setfenv(configfile, configenv)
-			configfile()
-			mineunit.deep_merge(configenv, mineunit._config, default_config)
-			-- Override config
-			if mineunit_conf_override then
-				for k, v in pairs(mineunit_conf_override) do
-					mineunit._config[k] = v
-				end
-			end
-			mineunit:infof("Mineunit configuration loaded from '%s'", configpath)
-		else
-			mineunit:warningf("Mineunit configuration failed: %s", err)
-		end
-	else
-		mineunit:warning("Mineunit configuration file not found")
-	end
-end
-
-do -- Read mod.conf config file
-	local modconfpath = source_path("mod.conf")
-	if not modconfpath then
-		mineunit:infof("mod.conf not found: '%s'", modconfpath)
-		return
-	end
-	local configfile = io.open(modconfpath, "r")
-	if configfile then
-		for line in configfile:lines() do
-			local key, value = string.gmatch(line, "([^=%s]+)%s*=%s*(.-)%s*$")()
-			if key == "name" then
-				if mineunit._config["modname"] then
-					mineunit:warning("Mod name defined in both mod.conf and mineunit.conf, using mineunit.conf")
-				else
-					mineunit._config["modname"] = value
-				end
-			end
-		end
-		mineunit:infof("Mod configuration loaded from '%s'", modconfpath)
-	else
-		mineunit:warning("Loading file mod.conf failed")
-	end
-end
-
--- Save original modname and set modpath
-mineunit._config["original_modname"] = mineunit:config("modname")
+-- Set modpath
 mineunit:set_modpath(mineunit:config("modname"), mineunit:config("root"))
 
 mineunit("deprecation")(function(msg)

--- a/init.lua
+++ b/init.lua
@@ -7,8 +7,13 @@ local pl = {
 }
 
 local lua_dofile = dofile
-function _G.dofile(path, ...)
-	return lua_dofile(pl.path.normpath(path), ...)
+function _G.dofile(path)
+	return lua_dofile(pl.path.normpath(path))
+end
+
+local lua_loadfile = loadfile
+function _G.loadfile(path, ...)
+	return lua_loadfile(pl.path.normpath(path), ...)
 end
 
 local default_config = {
@@ -43,28 +48,96 @@ mineunit._on_mods_loaded = {}
 mineunit._on_mods_loaded_exec_count = 0
 
 local tagged_paths = {
+	["."] = true,
 	["common"] = true,
 	["game"] = true
+}
+
+local blacklist_names = {
+	["common/strict"] = true,
+}
+
+local preload_modules = {
+	["game/auth"] = "auth",
 }
 
 require("mineunit.print")
 require("mineunit.globals")
 
-local function require_mineunit(name, root, tag)
+local _mineunits = {}
+local _subloader_preload
+
+local function require_filter(path, namepattern, loader, ...)
+	path = pl.path.normpath(path)
+	local name = path:gsub(namepattern, "%1")
+	if _mineunits[name] then
+		mineunit:debugf("Potential source of errors: reusing %s", name)
+		return _mineunits[name]
+	elseif blacklist_names[name] then
+		mineunit:debugf("Loader blacklisted %s", name)
+		return
+	end
+	mineunit:debugf("Loader accepted %s", name)
+	if preload_modules[name] then
+		mineunit:debugf("Loader preloading %s for %s", preload_modules[name], name)
+		_subloader_preload = name
+		mineunit(preload_modules[name], { strict = true })
+		--_mineunits[name] = {require_mineunit(redirect_names[name], nil, nil, true)}
+		--return _mineunits[name]
+	end
+	local result = {loader(path, ...)}
+	_mineunits[name] = result
+	return result
+end
+
+local _subloader_active = false
+local function require_mineunit(name, root, tag, strict)
 	mineunit:debugf("Loading mineunit module %s", name)
 	local modulename = name:gsub("/", ".")
 	if root and tag and tag ~= "mineunit" then
 		local path = name:match("^([^/]+)/")
 		if path and tagged_paths[path] then
+			mineunit:debugf("Loading %s from %s (%s)", name, tag, _subloader_active)
+			local namepattern = "^.*/" .. tag:gsub("([%.%-%+%*%%%(%)%[%]])", "%%%1") .. "/(.*)%.lua$"
 			local oldpath = package.path
-			local module
-			package.path = root.."/"..tag.."/?.lua;"
-			mineunit:debugf("Loading %s from %s", name, tag)
+			local module, original_dofile, original_loadfile
+			if not _subloader_active then
+				mineunit:debug("Enabling loader overrides")
+				local newpath = root.."/"..tag.."/?.lua;"
+				package.path = newpath
+				original_dofile = rawget(_G, "dofile")
+				original_loadfile = rawget(_G, "loadfile")
+				rawset(_G, "dofile", function (fpath)
+					_subloader_active = true
+					package.path = oldpath
+					local submod = require_filter(fpath, namepattern, lua_dofile)
+					package.path = newpath
+					_subloader_active = false
+					return submod and unpack(submod) or nil
+				end)
+				rawset(_G, "loadfile", function (fpath, ...)
+					_subloader_active = true
+					package.path = oldpath
+					local submod = require_filter(fpath, namepattern, lua_loadfile, ...)
+					package.path = newpath
+					_subloader_active = false
+					return submod and unpack(submod) or nil
+				end)
+			end
 			local success, err = pcall(function() module = require(modulename) end)
-			package.path = oldpath
+			if not _subloader_active then
+				mineunit:debug("Disabling loader overrides")
+				rawset(_G, "dofile", original_dofile)
+				rawset(_G, "loadfile", original_loadfile)
+				package.path = oldpath
+			end
 			if success then
 				mineunit:debugf("Loaded %s from %s", name, tag)
 				return module
+			elseif strict or _subloader_active then
+				mineunit:error(err)
+				mineunit:errorf("Loading %s from %s failed", name, tag)
+				error("Loading " .. name .. " from " .. tag .. " failed")
 			else
 				mineunit:debug(err)
 				mineunit:errorf("Loading %s from %s failed, trying builtin", name, tag)
@@ -75,11 +148,17 @@ local function require_mineunit(name, root, tag)
 end
 
 mineunit.__index = mineunit
-local _mineunits = {}
 setmetatable(mineunit, {
-	__call = function(self, name)
-		if _mineunits[name] == nil then
-			_mineunits[name] = {require_mineunit(name, mineunit:config("core_root"), mineunit:config("engine_version"))}
+	__call = function(self, name, options)
+		if name == _subloader_preload then
+			mineunit:debugf("Loader skipping queued module %s", name)
+			return
+		elseif _mineunits[name] == nil then
+			-- FIXME: hack to get around bad choices around module loader choices
+			local strict = options and options.strict
+			_mineunits[name] = {require_mineunit(
+				name, mineunit:config("core_root"), mineunit:config("engine_version"), strict
+			)}
 		end
 		return unpack(_mineunits[name])
 	end,

--- a/player.lua
+++ b/player.lua
@@ -81,23 +81,28 @@ function _G.core.show_formspec(playername, formname, formspec)
 		mineunit:debugf("core.show_formspec(%s, %s, %s)", playername, formname, formspec)
 		if formname == "" or formspec == "" then
 			player._formspec = nil
+			mineunit:warningf("core.show_formspec(%s, %s, <redacted>) destroyed form")
 		elseif mineunit:has_module("formspec")  then
 			player._formspec = mineunit:Form(formname, formspec)
 		else
 			player._formspec = { formname, formspec }
 		end
 	else
-		mineunit:debugf("core.show_formspec(%s, %s, <redacted>) failed, player not online", playername, formname)
+		mineunit:warningf("core.show_formspec(%s, %s, <redacted>) failed, player not online", playername, formname)
 	end
 end
 
 function _G.core.close_formspec(playername, formname)
 	local player = core.get_player_by_name(playername)
 	if player then
-		mineunit:debugf("core.show_formspec(%s, %s, %s)", playername, formname, formspec)
-		player._formspec = nil
+		if formname == "" or (player._formspec and player._formspec:name() == formname) then
+			player._formspec = nil
+			mineunit:debugf("core.close_formspec(%s, %s) destroyed form")
+		else
+			mineunit:infof("core.close_formspec(%s, %s) failed, this form is not active", playername, formname)
+		end
 	else
-		mineunit:debugf("core.show_formspec(%s, %s, <redacted>)", playername, formname)
+		mineunit:warningf("core.close_formspec(%s, %s) failed, player not online")
 	end
 end
 

--- a/player.lua
+++ b/player.lua
@@ -2,6 +2,8 @@ mineunit("formspec")
 mineunit("metadata")
 mineunit("entity")
 
+local hooks = mineunit.debughooks
+
 local players = {}
 
 function mineunit:get_players()
@@ -30,6 +32,7 @@ end
 
 if not _G.core.check_player_privs then
 	function _G.core.check_player_privs(player_or_name, ...)
+		hooks:pop()
 		assert.player_or_name(player_or_name, "core.check_player_privs: player_or_name: expected string or Player")
 		local player
 		if type(player_or_name) == "string" then
@@ -53,6 +56,7 @@ if not _G.core.check_player_privs then
 				end
 			end
 		end
+		hooks:push()
 		return #missing_privs == 0, #missing_privs > 0 and missing_privs or ""
 	end
 end
@@ -300,6 +304,7 @@ end
 -- TODO: do_metadata_inventory_put does not follow exact engine behavior but should be fine for testing simple inv moves
 -- TODO: It might be simpler and more useful for tests to just discard leftovers and always clear source inventory
 function Player:do_metadata_inventory_put(pos, tolist, toindex, index_or_stack)
+	hooks:pop()
 	-- Get node name and definition at target position
 	local name = core.get_node(pos).name
 	local def = core.registered_nodes[name]
@@ -321,7 +326,7 @@ function Player:do_metadata_inventory_put(pos, tolist, toindex, index_or_stack)
 	local stack = frominv:get_stack("main", fromindex)
 	local can_put_count
 	if def.allow_metadata_inventory_put then
-		can_put_count = def.allow_metadata_inventory_put(pos, tolist, toindex, stack, self)
+		can_put_count = hooks:get(def.allow_metadata_inventory_put, pos, tolist, toindex, stack, self)
 		assert(type(can_put_count) == "number", "allow_metadata_inventory_put returns invalid value for "..name)
 	else
 		can_put_count = stack:get_count()
@@ -334,20 +339,23 @@ function Player:do_metadata_inventory_put(pos, tolist, toindex, index_or_stack)
 
 		-- Execute callbacks
 		if def.on_metadata_inventory_put and not placedstack:is_empty() then
-			def.on_metadata_inventory_put(pos, tolist, toindex, placedstack, self)
+			hooks:call(def.on_metadata_inventory_put, pos, tolist, toindex, placedstack, self)
 		end
 	end
+	hooks:push()
 	return can_put_count
 end
 
 function Player:do_metadata_inventory_take(pos, listname, index)
+	hooks:pop()
 	-- Test if items can be moved
 	local def = core.registered_nodes[core.get_node(pos).name]
 	local inv = core.get_meta(pos):get_inventory()
 	local stack = inv:get_stack(listname, index)
 	local can_take_count = stack:get_count()
 	if def.allow_metadata_inventory_take then
-		can_take_count = math.min(def.allow_metadata_inventory_take(pos, listname, index, stack, self), can_take_count)
+		local would_take = hooks:get(def.allow_metadata_inventory_take, pos, listname, index, stack, self)
+		can_take_count = math.min(would_take, can_take_count)
 	end
 	-- Move items
 	if can_take_count > 0 then
@@ -360,14 +368,16 @@ function Player:do_metadata_inventory_take(pos, listname, index)
 		inv:set_stack(listname, index, ItemStack(nil))
 		-- Callbacks
 		if def.on_metadata_inventory_put then
-			def.on_metadata_inventory_take(pos, listname, index, stack, self)
+			hooks:call(def.on_metadata_inventory_take, pos, listname, index, stack, self)
 		end
 	end
+	hooks:push()
 end
 
 function Player:do_set_wieldslot(inv_slot) self._wield_index = inv_slot end
 
 function Player:do_use(...) -- (pointed_thing/pos/controls, controls if arg1)
+	hooks:pop()
 	-- TODO: Default should probably be position in front of player instead of player itself
 	local pointed_thing_or_pos, controls = resolve_player_action_args(...)
 	local item = self:get_wielded_item()
@@ -375,9 +385,8 @@ function Player:do_use(...) -- (pointed_thing/pos/controls, controls if arg1)
 	if itemdef and itemdef.on_use then
 		mineunit:debugf("%s:do_use(%s, %s) with %s", self, pointed_thing_or_pos, controls, item)
 		local pointed_thing = get_pointed_thing(self, pointed_thing_or_pos, itemdef.range)
-		local returnstack
 		tempcontrols(self, controls)
-		returnstack = itemdef.on_use(item, self, pointed_thing)
+		local returnstack = hooks:get(itemdef.on_use, item, self, pointed_thing)
 		restorecontrols(self)
 		if returnstack then
 			assert.is_ItemStack(returnstack)
@@ -386,6 +395,7 @@ function Player:do_use(...) -- (pointed_thing/pos/controls, controls if arg1)
 	else
 		mineunit:debugf("%s:do_use(%s, %s) with unknown %s", self, pointed_thing_or_pos, controls, item)
 	end
+	hooks:push()
 end
 
 function Player:do_use_from_above(pos, controls)
@@ -400,6 +410,7 @@ function Player:do_use_from_above(pos, controls)
 end
 
 function Player:do_place(...) -- (pointed_thing/pos/controls, controls if arg1)
+	hooks:pop()
 	-- TODO: Default should probably be position in front of player instead of player itself
 	local pointed_thing_or_pos, controls = resolve_player_action_args(...)
 	local item = self:get_wielded_item()
@@ -410,9 +421,9 @@ function Player:do_place(...) -- (pointed_thing/pos/controls, controls if arg1)
 		local returnstack
 		tempcontrols(self, controls)
 		if itemdef.on_place and pointed_thing.type == "node" then
-			returnstack = itemdef.on_place(item, self, pointed_thing)
+			returnstack = hooks:get(itemdef.on_place, item, self, pointed_thing)
 		elseif itemdef.on_secondary_use and pointed_thing.type ~= "node" then
-			returnstack = itemdef.on_secondary_use(item, self, pointed_thing)
+			returnstack = hooks:get(itemdef.on_secondary_use, item, self, pointed_thing)
 		end
 		restorecontrols(self)
 		if returnstack then
@@ -422,6 +433,7 @@ function Player:do_place(...) -- (pointed_thing/pos/controls, controls if arg1)
 	else
 		mineunit:debugf("%s:do_place(%s, %s) with unknown %s", self, pointed_thing_or_pos, controls, item)
 	end
+	hooks:push()
 end
 
 function Player:do_place_from_above(pos, controls)

--- a/player.lua
+++ b/player.lua
@@ -4,8 +4,6 @@ function mineunit:get_players()
 	return players
 end
 
-function _G.core.show_formspec(...) mineunit:info("core.show_formspec", ...) end
-
 function _G.core.get_player_privs(name)
 	assert.is_string(name, "core.get_player_privs: name: expected string, got "..type(name))
 	assert.is_Player(players[name], "core.get_player_privs: player not found: "..name)
@@ -72,6 +70,26 @@ function _G.core.get_connected_players()
 		end
 	end
 	return result
+end
+
+function _G.core.show_formspec(playername, formname, formspec)
+	local player = core.get_player_by_name(playername)
+	if player and mineunit:has_module("formspec") then
+		mineunit:debugf("core.show_formspec(%s, %s, %s)", playername, formname, formspec)
+		player._formspec = mineunit:Form(formname, formspec)
+	else
+		mineunit:debugf("core.show_formspec(%s, %s, <redacted>)", playername, formname)
+	end
+end
+
+function _G.core.close_formspec(playername, formname)
+	local player = core.get_player_by_name(playername)
+	if player then
+		mineunit:debugf("core.show_formspec(%s, %s, %s)", playername, formname, formspec)
+		player._formspec = nil
+	else
+		mineunit:debugf("core.show_formspec(%s, %s, <redacted>)", playername, formname)
+	end
 end
 
 function _G.core.get_player_information(name)
@@ -485,6 +503,7 @@ function Player:do_reset()
 	self._inv = InvRef()
 	self._inv:set_size("main", 32)
 	self._object:set_properties(table.copy(default_player_properties))
+	self._formspec = nil
 	self._hud_flags = { hotbar = true, healthbar = true, crosshair = true,
 		wielditem = true, breathbar = true, minimap = false, minimap_radar = false }
 end
@@ -621,6 +640,7 @@ mineunit.export_object(Player, {
 			_is_player = true,
 			_privs = privs or { server = 1, interact = 1, test_priv = 1 },
 			_object = ObjectRef(),
+			_formspec = nil,
 			_look_dir = {x=0,y=-1,z=0}, -- Reflects simplified pointed_thing used to place nodes
 			_eye_offset_first = {x=0,y=0,z=0},
 			_eye_offset_third = {x=0,y=0,z=0},

--- a/player.lua
+++ b/player.lua
@@ -54,6 +54,7 @@ if not _G.core.check_player_privs then
 end
 
 function _G.core.get_player_by_name(name)
+	assert.is_string(name, "core.get_player_by_name: name: expected string, got "..type(name))
 	return players[name] and players[name]._online and players[name] or nil
 end
 
@@ -73,12 +74,20 @@ function _G.core.get_connected_players()
 end
 
 function _G.core.show_formspec(playername, formname, formspec)
+	assert.is_string(formname, "core.show_formspec: formname: expected string, got "..type(formname))
+	assert.is_string(formspec, "core.show_formspec: formspec: expected string, got "..type(formspec))
 	local player = core.get_player_by_name(playername)
-	if player and mineunit:has_module("formspec") then
+	if player then
 		mineunit:debugf("core.show_formspec(%s, %s, %s)", playername, formname, formspec)
-		player._formspec = mineunit:Form(formname, formspec)
+		if formname == "" or formspec == "" then
+			player._formspec = nil
+		elseif mineunit:has_module("formspec")  then
+			player._formspec = mineunit:Form(formname, formspec)
+		else
+			player._formspec = { formname, formspec }
+		end
 	else
-		mineunit:debugf("core.show_formspec(%s, %s, <redacted>)", playername, formname)
+		mineunit:debugf("core.show_formspec(%s, %s, <redacted>) failed, player not online", playername, formname)
 	end
 end
 
@@ -90,6 +99,12 @@ function _G.core.close_formspec(playername, formname)
 	else
 		mineunit:debugf("core.show_formspec(%s, %s, <redacted>)", playername, formname)
 	end
+end
+
+function mineunit:get_player_formspec(player_or_name)
+	assert.player_or_name(player_or_name, "mineunit:get_player_formspec: player_or_name: expected string or Player")
+	local player = type(player_or_name) == "string" and players[player_or_name] or player_or_name
+	return type(player._formspec) == "table" and unpack(player._formspec) or player._formspec
 end
 
 function _G.core.get_player_information(name)
@@ -583,10 +598,10 @@ function Player:get_attribute(attribute)
 	error("NOT IMPLEMENTED")
 end
 
-function Player:set_inventory_formspec(formspec) end
-function Player:get_inventory_formspec() return "" end
-function Player:set_formspec_prepend(formspec) end
-function Player:get_formspec_prepend(formspec) return "" end
+function Player:set_inventory_formspec(formspec) self._inventory_formspec = formspec end
+function Player:get_inventory_formspec() return self._inventory_formspec end
+function Player:set_formspec_prepend(formspec) self._formspec_prepend = formspec end
+function Player:get_formspec_prepend(formspec) return self._formspec_prepend end
 
 function Player:hud_get_flags() return self._hud_flags end
 function Player:set_hud_flags(new_flags)
@@ -641,6 +656,8 @@ mineunit.export_object(Player, {
 			_privs = privs or { server = 1, interact = 1, test_priv = 1 },
 			_object = ObjectRef(),
 			_formspec = nil,
+			_inventory_formspec = nil,
+			_formspec_prepend = nil,
 			_look_dir = {x=0,y=-1,z=0}, -- Reflects simplified pointed_thing used to place nodes
 			_eye_offset_first = {x=0,y=0,z=0},
 			_eye_offset_third = {x=0,y=0,z=0},

--- a/player.lua
+++ b/player.lua
@@ -178,44 +178,6 @@ end
 
 local Player = {}
 
--- Exported while playing default minetest game
-local default_player_properties = {
-	selectionbox = { -0.3, 0, -0.3, 0.3, 1.7, 0.3 },
-	nametag = "",
-	nametag_bgcolor = false,
-	infotext = "",
-	static_save = true,
-	backface_culling = false,
-	makes_footstep_sound = true,
-	is_visible = true,
-	textures = { "character.png" },
-	physical = false,
-	stepheight = 0.60000002384186,
-	collisionbox = { -0.3, 0, -0.3, 0.3, 1.7, 0.3 },
-	initial_sprite_basepos = { y = 0, x = 0 },
-	use_texture_alpha = false,
-	show_on_minimap = true,
-	automatic_face_movement_dir = false,
-	spritediv = { y = 1, x = 1 },
-	breath_max = 10,
-	nametag_color = { a = 255, b = 255, g = 255, r = 255 },
-	visual_size = { y = 1, x = 1, z = 1 },
-	mesh = "character.b3d",
-	visual = "mesh",
-	collide_with_objects = true,
-	damage_texture_modifier = "^[brighten",
-	shaded = true,
-	pointable = true,
-	zoom_fov = 0,
-	eye_height = 1.4700000286102,
-	colors = {{ a = 255, b = 255, g = 255, r = 255 }},
-	automatic_rotate = 0,
-	hp_max = 20,
-	wield_item = "", -- TODO: This should probably be actual item in Player:_wield_index inventory slot
-	automatic_face_movement_max_rotation_per_sec = -1,
-	glow = 0
-}
-
 --
 -- Mineunit player API methods
 --
@@ -522,14 +484,62 @@ end
 function Player:do_reset()
 	self._controls = {}
 	self._oldcontrols = nil
+	self._breath = 10
+	self._hp = 20
 	self._wield_index = 1
 	self._meta = MetaDataRef()
 	self._inv = InvRef()
 	self._inv:set_size("main", 32)
-	self._object:set_properties(table.copy(default_player_properties))
 	self._formspec = nil
-	self._hud_flags = { hotbar = true, healthbar = true, crosshair = true,
-		wielditem = true, breathbar = true, minimap = false, minimap_radar = false }
+	self._hud_flags = {
+		hotbar = true,
+		healthbar = true,
+		crosshair = true,
+		wielditem = true,
+		breathbar = true,
+		minimap = false,
+		minimap_radar = false,
+	}
+	local selectionbox = { -0.3, 0, -0.3, 0.3, 1.7, 0.3 }
+	self._object:set_properties({
+		selectionbox = selectionbox,
+		nametag = "",
+		nametag_bgcolor = false,
+		infotext = "",
+		static_save = true,
+		backface_culling = false,
+		makes_footstep_sound = true,
+		is_visible = true,
+		textures = { "character.png" },
+		physical = false,
+		stepheight = 0.60000002384186,
+		collisionbox = selectionbox,
+		initial_sprite_basepos = { y = 0, x = 0 },
+		use_texture_alpha = false,
+		show_on_minimap = true,
+		automatic_face_movement_dir = false,
+		spritediv = { y = 1, x = 1 },
+		breath_max = 10,
+		nametag_color = { a = 255, b = 255, g = 255, r = 255 },
+		visual_size = { y = 1, x = 1, z = 1 },
+		mesh = "character.b3d",
+		visual = "mesh",
+		collide_with_objects = true,
+		damage_texture_modifier = "^[brighten",
+		shaded = true,
+		pointable = true,
+		zoom_fov = core.settings:get_bool("creative_mode", false) and 15 or 0,
+		eye_height = 1.4700000286102,
+		colors = {{ a = 255, b = 255, g = 255, r = 255 }},
+		automatic_rotate = 0,
+		hp_max = 20,
+		wield_item = "", -- TODO: This should probably be actual item in Player:_wield_index inventory slot
+		automatic_face_movement_max_rotation_per_sec = -1,
+		glow = 0
+	})
+	self._object:set_armor_groups({
+		immortal = core.settings:get_bool("enable_damage") and 1 or nil
+	})
 end
 
 --
@@ -582,10 +592,10 @@ function Player:set_look_yaw(radians)
 	error("NOT IMPLEMENTED")
 end
 
-function Player:get_breath() error("NOT IMPLEMENTED") end
-function Player:set_breath(value) error("NOT IMPLEMENTED") end
+function Player:get_breath() return self._breath end
+function Player:set_breath(value) self._breath = math.max(0, math.min(10, value)) end
 function Player:set_fov(fov, is_multiplier, transition_time) error("NOT IMPLEMENTED") end
-function Player:get_fov() error("NOT IMPLEMENTED") end
+function Player:get_fov() return 0, false, 0 end
 
 function Player:get_eye_offset() return self._eye_offset_first, self._eye_offset_third end
 function Player:set_eye_offset(firstperson, thirdperson)
@@ -627,9 +637,9 @@ function Player:set_formspec_prepend(formspec) self._formspec_prepend = formspec
 function Player:get_formspec_prepend(formspec) return self._formspec_prepend end
 
 function Player:hud_get_flags() return self._hud_flags end
-function Player:set_hud_flags(new_flags)
+function Player:hud_set_flags(new_flags)
 	for flag, value in pairs(new_flags) do
-		if nil ~= self._hud_flags[flag] then
+		if self._hud_flags[flag] ~= nil then
 			self._hud_flags[flag] = not not value
 		end
 	end
@@ -665,17 +675,10 @@ mineunit.export_object(Player, {
 			-- Players are always online if server module is not loaded
 			_online = not (mineunit.execute_on_joinplayer and true or false),
 			_address = nil,
-			_connection_info = nil, --[[{
-				min_rtt = 0,
-				max_rtt = 0,
-				avg_rtt = 0,
-				min_jitter = 0,
-				max_jitter = 0,
-				avg_jitter = 0,
-			},--]]
+			_connection_info = nil, -- server module injects connection info during join
 			_client_info = nil,
-			_is_player = true,
-			_privs = privs or { server = 1, interact = 1, test_priv = 1 },
+			_is_player = true, -- TODO: Why is this here? Consider removing it.
+			_privs = privs or { server = 1, interact = 1, test_priv = 1 }, -- Auth module can override privs
 			_object = ObjectRef(),
 			_formspec = nil,
 			_inventory_formspec = nil,
@@ -683,6 +686,8 @@ mineunit.export_object(Player, {
 			_look_dir = {x=0,y=-1,z=0}, -- Reflects simplified pointed_thing used to place nodes
 			_eye_offset_first = {x=0,y=0,z=0},
 			_eye_offset_third = {x=0,y=0,z=0},
+			_breath = nil,
+			_hp = nil,
 		}
 		Player.do_reset(obj)
 		if mineunit:has_module("auth") then

--- a/player.lua
+++ b/player.lua
@@ -648,6 +648,21 @@ end
 function Player:set_formspec_prepend(formspec) self._formspec_prepend = formspec end
 function Player:get_formspec_prepend(formspec) return self._formspec_prepend end
 
+function Player:hud_add(def)
+	mineunit:debugf("noop! %s:hud_add(%t)", self, def)
+end
+function Player:hud_remove(id)
+	mineunit:debugf("noop! %s:hud_remove(%s)", self, id)
+end
+function Player:hud_change(id, stat, value)
+	mineunit:debugf("noop! %s:hud_change(%s, %s, %s)", self, id, stat, value)
+end
+function Player:hud_get(id)
+	mineunit:debugf("noop! %s:hud_get(%s)", self, id)
+end
+function Player:hud_get_all()
+	mineunit:debugf("noop! %s:hud_get_all()", self)
+end
 function Player:hud_get_flags() return self._hud_flags end
 function Player:hud_set_flags(new_flags)
 	for flag, value in pairs(new_flags) do

--- a/player.lua
+++ b/player.lua
@@ -1,3 +1,7 @@
+mineunit("formspec")
+mineunit("metadata")
+mineunit("entity")
+
 local players = {}
 
 function mineunit:get_players()
@@ -82,10 +86,12 @@ function _G.core.show_formspec(playername, formname, formspec)
 		if formname == "" or formspec == "" then
 			player._formspec = nil
 			mineunit:warningf("core.show_formspec(%s, %s, <redacted>) destroyed form")
-		elseif mineunit:has_module("formspec")  then
-			player._formspec = mineunit:Form(formname, formspec)
 		else
-			player._formspec = { formname, formspec }
+			if player._formspec_prepend then
+				player._formspec = mineunit:Form(formname, formspec .. player._formspec_prepend)
+			else
+				player._formspec = mineunit:Form(formname, formspec)
+			end
 		end
 	else
 		mineunit:warningf("core.show_formspec(%s, %s, <redacted>) failed, player not online", playername, formname)
@@ -109,7 +115,7 @@ end
 function mineunit:get_player_formspec(player_or_name)
 	assert.player_or_name(player_or_name, "mineunit:get_player_formspec: player_or_name: expected string or Player")
 	local player = type(player_or_name) == "string" and players[player_or_name] or player_or_name
-	return type(player._formspec) == "table" and unpack(player._formspec) or player._formspec
+	return player._formspec
 end
 
 function _G.core.get_player_information(name)
@@ -169,8 +175,6 @@ end
 --
 -- Mineunit player fixture API
 --
-
-mineunit("metadata")
 
 local Player = {}
 
@@ -603,8 +607,22 @@ function Player:get_attribute(attribute)
 	error("NOT IMPLEMENTED")
 end
 
-function Player:set_inventory_formspec(formspec) self._inventory_formspec = formspec end
-function Player:get_inventory_formspec() return self._inventory_formspec end
+function Player:set_inventory_formspec(formspec)
+	if formspec == "" then
+		-- Inventory is disabled if formspec is empty.
+		self._inventory_formspec = nil
+	else
+		-- Empty formspec name is player inventory
+		self._inventory_formspec = mineunit:Form("", formspec)
+	end
+end
+
+function Player:get_inventory_formspec()
+	return self._inventory_formspec
+		and self._inventory_formspec:text()
+		or nil
+end
+
 function Player:set_formspec_prepend(formspec) self._formspec_prepend = formspec end
 function Player:get_formspec_prepend(formspec) return self._formspec_prepend end
 
@@ -637,7 +655,6 @@ function Player:__tostring()
 	return self._name
 end
 
-mineunit("entity")
 mineunit.export_object(Player, {
 	name = "Player",
 	constructor = function(self, name, privs)

--- a/player.lua
+++ b/player.lua
@@ -497,7 +497,6 @@ function Player:do_reset()
 	self._controls = {}
 	self._oldcontrols = nil
 	self._breath = 10
-	self._hp = 20
 	self._wield_index = 1
 	self._meta = MetaDataRef()
 	self._inv = InvRef()
@@ -512,6 +511,7 @@ function Player:do_reset()
 		minimap = false,
 		minimap_radar = false,
 	}
+	self._object._hp = 20
 	local selectionbox = { -0.3, 0, -0.3, 0.3, 1.7, 0.3 }
 	self._object:set_properties({
 		selectionbox = selectionbox,
@@ -604,6 +604,11 @@ function Player:set_look_yaw(radians)
 	error("NOT IMPLEMENTED")
 end
 
+function Player:set_hp(hp, reason)
+	-- TODO: execute callbacks register_on_player_hpchange
+	-- TBD: move hp_max limiter into ObjectRef:set_hp?
+	self._object:set_hp(math.max(hp, self._object:get_properties().hp_max))
+end
 function Player:get_breath() return self._breath end
 function Player:set_breath(value) self._breath = math.max(0, math.min(10, value)) end
 function Player:set_fov(fov, is_multiplier, transition_time) error("NOT IMPLEMENTED") end
@@ -714,7 +719,6 @@ mineunit.export_object(Player, {
 			_eye_offset_first = {x=0,y=0,z=0},
 			_eye_offset_third = {x=0,y=0,z=0},
 			_breath = nil,
-			_hp = nil,
 		}
 		Player.do_reset(obj)
 		if mineunit:has_module("auth") then

--- a/print.lua
+++ b/print.lua
@@ -4,6 +4,12 @@
 
 local luaprint = _G.print
 local luatype = mineunit.utils and mineunit.utils.luatype or _G.type
+local debug = debug
+
+-- Used in case engine core libraries have not been loaded yet
+function dump(thing)
+	return require('luassert.state').format_argument(thing) or tostring(thing)
+end
 
 function mineunit:prepend_print(s)
 	self._prepend_output = s
@@ -24,6 +30,10 @@ end
 local formatters = {
 	["nil"] = tostring,
 	["xnil"] = tostring,
+	["function"] = tostring,
+	["xfunction"] = tostring,
+	["userdata"] = tostring,
+	["xuserdata"] = tostring,
 	--luacheck: push ignore 561 cyclomatic complexity
 	["table"] = function(thing)
 		local above = rawget(thing, "above")
@@ -51,16 +61,30 @@ local formatters = {
 	--luacheck: pop
 	["xtable"] = tostring,
 	["number"] = tostring,
-	["xnumber"] = tostring,
+	["xnumber"] = function(d) return ("%x"):format(d) end,
+	["string"] = tostring,
+	["xstring"] = function(s)
+		return s:gsub("(.)(.?)", function(a,b)
+			return b == "" and ("%02x"):format(a:byte()) or ("%02x%02x "):format(a:byte(),b:byte())
+		end)
+	end,
 	["boolean"] = tostring,
-	["xboolean"] = tostring,
+	["xboolean"] = function(b) return b and "1" or "0" end,
 }
 
-local function fmtprint(fmtstr, ...)
+local function fmtargs(s)
+	local pos, _, ch = 0
+	return function()
+		pos, _, ch = s:find("%%([sx@t])", pos + 1)
+		return pos, ch
+	end
+end
+
+local function formatter(fmtstr, ...)
 	local args = {...}
-	local matcher = fmtstr:gmatch("%%(.)")
+	local matcher = fmtargs(fmtstr)
 	local index = 0
-	for argtype in matcher do
+	for pos, argtype in matcher do
 		index = index + 1
 		local t = luatype(args[index])
 		if formatters[t] then
@@ -70,10 +94,18 @@ local function fmtprint(fmtstr, ...)
 				args[index] = formatters["x"..t](args[index])
 			elseif argtype == "t" then
 				args[index] = dump(args[index])
+			elseif argtype == "@" then
+				local level = (tonumber(fmtstr:sub(pos + 1, pos + 1)) or 0) + 4
+				local trace = debug.getinfo(level, "Sl")
+				table.insert(args, index, trace.source:sub(2) .. ":" .. tostring(trace.currentline))
 			end
 		end
 	end
-	return printwrapper(fmtstr:gsub("%%t", "%%s"):format(unpack(args)))
+	return fmtstr:gsub("%%[tx@]", "%%s"):format(unpack(args))
+end
+
+local function fmtprint(fmtstr, ...)
+	return printwrapper(formatter(fmtstr, ...))
 end
 
 function mineunit:debug(...)   if self:config("verbose") > 3 then printwrapper("D:",...) end end
@@ -87,5 +119,6 @@ function mineunit:infof(fmtstr, ...)    if self:config("verbose") > 2 then fmtpr
 function mineunit:warningf(fmtstr, ...) if self:config("verbose") > 1 then fmtprint("W: "..fmtstr,...) end end
 function mineunit:errorf(fmtstr, ...)   if self:config("verbose") > 0 then fmtprint("E: "..fmtstr,...) end end
 function mineunit:printf(fmtstr, ...)   if self:config("print")       then fmtprint(fmtstr,...) end end
+mineunit.format = formatter
 
 _G.print = function(...) mineunit:print(...) end

--- a/server.lua
+++ b/server.lua
@@ -181,6 +181,7 @@ function mineunit:execute_on_joinplayer(player, options)
 		max_jitter = options.max_jitter or 0,
 		avg_jitter = options.avg_jitter or 0,
 	})
+	player._formspec = nil
 	if core.get_auth_handler then
 		local name = player:get_player_name()
 		local data = core.get_auth_handler().get_auth(name)
@@ -210,6 +211,7 @@ end
 function mineunit:execute_on_leaveplayer(player, timeout)
 	assert.is_Player(player, "Invalid call to mineunit:execute_on_leaveplayer")
 	player._online = false
+	player._formspec = nil
 	return core.run_callbacks(
 		core.registered_on_leaveplayers,
 		RunCallbacksMode.RUN_CALLBACKS_MODE_FIRST,

--- a/server.lua
+++ b/server.lua
@@ -1,3 +1,4 @@
+local hooks = mineunit.debughooks
 
 --
 -- Storage for node timers
@@ -88,7 +89,7 @@ local function run_abm(spec)
 			local pos = core.get_position_from_hash(id)
 			if not spec.neighbors or match_neighbor(pos, spec._neighbors_nodes, spec._neighbors_groups) then
 				-- FIXME: active_object_count, active_object_count_wider. Entities not supported by mineunit.
-				spec.action(pos, node, 0, 0)
+				hooks:call(spec.action, pos, node, 0, 0)
 			end
 		end
 	end
@@ -115,25 +116,32 @@ local entitystep_collision_data = {
 	collisions = {}
 }
 function mineunit:execute_entitystep(dtime, filter)
+	hooks:pop()
 	if filter then
 		-- Execute on_step for named entities
 		mineunit:debug("Executing entity step", filter)
 		local list = mineunit:get_entities()[filter]
 		for _, entity in ipairs(list) do
-			entity:get_luaentity():on_step(dtime, table.copy(entitystep_collision_data))
+			local luaentity = entity:get_luaentity()
+			local cdata = table.copy(entitystep_collision_data)
+			hooks:call(luaentity.on_step, luaentity, dtime, cdata)
 		end
 	else
 		-- Execute on_step for all entities
 		for group, list in pairs(mineunit:get_entities()) do
 			mineunit:debug("Executing entity step", group)
 			for _, entity in ipairs(list) do
-				entity:get_luaentity():on_step(dtime, table.copy(entitystep_collision_data))
+				local luaentity = entity:get_luaentity()
+				local cdata = table.copy(entitystep_collision_data)
+				hooks:call(luaentity.on_step, luaentity, dtime, cdata)
 			end
 		end
 	end
+	hooks:push()
 end
 
 function mineunit:execute_globalstep(dtime)
+	hooks:pop()
 	-- Default server step is 0.1 seconds
 	assert(dtime == nil or type(dtime) == "number", "Invalid call to mineunit:execute_globalstep")
 	dtime = dtime or 0.1
@@ -141,7 +149,8 @@ function mineunit:execute_globalstep(dtime)
 		mineunit:execute_entitystep(dtime)
 	end
 	for node_id, timer in pairs(world_nodetimers) do
-		timer:_step(dtime, core.get_position_from_hash(node_id))
+		local pos = core.get_position_from_hash(node_id)
+		hooks:call(timer._step, timer, dtime, pos)
 	end
 	for _,spec in pairs(core.registered_abms) do
 		spec._dtime = spec._dtime and spec._dtime + dtime or dtime
@@ -150,6 +159,7 @@ function mineunit:execute_globalstep(dtime)
 			spec._dtime = 0
 		end
 	end
+	hooks:push()
 	return core.run_callbacks(
 		core.registered_globalsteps,
 		RunCallbacksMode.RUN_CALLBACKS_MODE_FIRST,
@@ -165,6 +175,7 @@ function mineunit:execute_shutdown()
 end
 
 function mineunit:execute_on_joinplayer(player, options)
+	hooks:pop()
 	assert.is_Player(player, "mineunit:execute_on_joinplayer 1st arg should be Player")
 	if options == nil then
 		options = {}
@@ -187,7 +198,7 @@ function mineunit:execute_on_joinplayer(player, options)
 		local data = core.get_auth_handler().get_auth(name)
 		core.set_player_privs(name, data.privileges)
 		mineunit:debugf("Auth privileges: %s, %t", player, player._privs)
-		local message = core.run_callbacks(
+		local message = hooks:get(core.run_callbacks,
 			core.registered_on_prejoinplayers,
 			RunCallbacksMode.RUN_CALLBACKS_MODE_OR,
 			name,
@@ -195,11 +206,13 @@ function mineunit:execute_on_joinplayer(player, options)
 		)
 		if message then
 			mineunit:debugf("Kicked %s (%s) by 'on_prejoinplayers': %s", player, address, message)
+			hooks:push()
 			return message
 		end
 		mineunit:execute_globalstep()
 	end
 	player._online = true
+	hooks:push()
 	return core.run_callbacks(
 		core.registered_on_joinplayers,
 		RunCallbacksMode.RUN_CALLBACKS_MODE_FIRST,
@@ -221,8 +234,8 @@ function mineunit:execute_on_leaveplayer(player, timeout)
 end
 
 function mineunit:execute_on_chat_message(sender, message)
-	assert(type(sender) == "string", "Invalid call to mineunit:execute_modchannel_message")
-	assert(type(message) == "string", "Invalid call to mineunit:execute_modchannel_message")
+	assert(type(sender) == "string", "Invalid call to mineunit:execute_on_chat_message")
+	assert(type(message) == "string", "Invalid call to mineunit:execute_on_chat_message")
 	return core.run_callbacks(
 		core.registered_on_chat_messages,
 		RunCallbacksMode.RUN_CALLBACKS_MODE_OR_SC,

--- a/spec/debug_spec.lua
+++ b/spec/debug_spec.lua
@@ -1,0 +1,177 @@
+-- For self tests package path must be set in a way that makes package loaders search current directory first
+package.path = "./?.lua;../?/init.lua;../?.lua;" --.. package.path
+
+require("mineunit")
+
+local hooks = mineunit.debughooks
+if not hooks.available then
+	mineunit:warning("Tests skipped: Debug hooks not available.")
+	return
+end
+
+assert(debug.gethook() == nil, "Debug hooks should be disabled within spec root")
+mineunit:config_set("silence_global_export_overrides", true)
+
+local mt_not_nil = setmetatable({}, {
+	__index = function()
+		assert.not_nil(debug.gethook())
+		return function()
+			assert.not_nil(debug.gethook())
+		end
+	end
+})
+
+local mt_is_nil = setmetatable({}, {
+	__index = function()
+		assert.is_nil(debug.gethook())
+		return function()
+			assert.is_nil(debug.gethook())
+		end
+	end
+})
+
+local on_mods_loaded_called = false
+core.register_on_mods_loaded(function()
+	on_mods_loaded_called = true
+	assert.not_nil(debug.gethook(), "Debug hooks should be enabled for core.registered_on_mods_loaded")
+end)
+
+-- Debug hooks should be disabled outside of describe() block
+assert.is_nil(debug.gethook(), "Debug hooks should be disabled within spec root")
+
+-- Debug hooks should get enabled when mods_loaded() is called from spec root
+mineunit:mods_loaded()
+assert.is_true(on_mods_loaded_called, "core.registered_on_mods_loaded not executed")
+
+-- Debug hooks should still be disabled outside of describe() block
+assert.is_nil(debug.gethook(), "Debug hooks should be disabled within spec root")
+
+describe("Mineunit debug hooks", function()
+
+	-- Should also have debug hooks in describe() body
+	assert.not_nil(debug.gethook(), "Debug hooks should be enabled within describe root")
+
+	it("it has debug hook", function()
+		assert.not_nil(debug.gethook())
+	end)
+
+	describe("nested describe", function()
+		assert.not_nil(debug.gethook(), "Debug hooks should be enabled within nested describe root")
+		it("it has debug hook", function()
+			assert.not_nil(debug.gethook())
+		end)
+	end)
+
+	it("pop/push disables and enables hooks", function()
+		assert.not_nil(debug.gethook())
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		hooks:push()
+		assert.not_nil(debug.gethook())
+	end)
+
+	it("nested pop/push disables and enables hooks", function()
+		assert.not_nil(debug.gethook())
+		-- pop x3, hooks should stay disabled
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		-- push x3, third push should enable hooks
+		hooks:push()
+		assert.is_nil(debug.gethook())
+		hooks:push()
+		assert.is_nil(debug.gethook())
+		hooks:push()
+		assert.not_nil(debug.gethook())
+		-- pop + push once afterwards
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		hooks:push()
+		assert.not_nil(debug.gethook())
+	end)
+
+	it("gets disabled after call", function()
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		hooks:call(function(arg)
+			assert.equals(1, arg)
+			assert.not_nil(debug.gethook())
+		end, 1)
+		-- Debug hooks get disabled if inactive before hooks:call()
+		assert.is_nil(debug.gethook())
+		-- Should normally always call push after pop but we are not doing that here
+		-- because debug hooks gets reset after every test case, it should also be
+		-- called through finally() instead of directly as tests might fail.
+		-- hooks:push()
+	end)
+
+	it("can be restored after call", function()
+		hooks:pop()
+		assert.is_nil(debug.gethook())
+		local called = false
+		hooks:call(function(arg)
+			assert.equals(1, arg)
+			assert.not_nil(debug.gethook())
+			called = true
+		end, 1)
+		assert.is_true(called)
+		-- Debug hooks get enabled again with hooks:push()
+		hooks:push()
+		assert.not_nil(debug.gethook())
+	end)
+
+	it("stays enabled after call", function()
+		assert.not_nil(debug.gethook())
+		local called = false
+		hooks:call(function(arg)
+			assert.equals(2, arg)
+			assert.not_nil(debug.gethook())
+			called = true
+		end, 2)
+		assert.is_true(called)
+		-- Debug hooks stay enabled if active before hooks:call()
+		assert.not_nil(debug.gethook())
+	end)
+
+	it("stays enabled for __index", function()
+		-- mt_not_nil.__index first executes assert.not_nil(debug.gethook())
+		-- and then also retuns function that executes assert.not_nil(debug.gethook())
+		mt_not_nil.test()
+		-- Debug hooks should stay enabled afterwards
+		assert.not_nil(debug.gethook())
+	end)
+
+	it("stays disabled for __index after pop", function()
+		hooks:pop()
+		-- mt_is_nil.__index first executes assert.is_nil(debug.gethook())
+		-- and then also retuns function that executes assert.is_nil(debug.gethook())
+		mt_is_nil.test()
+		-- Debug hooks should stay disabled afterwards
+		assert.is_nil(debug.gethook())
+	end)
+
+	it("stays enabled for __index within call", function()
+		hooks:call(function(arg)
+			mt_not_nil.test()
+		end)
+	end)
+
+	it("is enabled for __index within call after pop", function()
+		hooks:pop()
+		hooks:call(function(arg)
+			mt_not_nil.test()
+		end)
+	end)
+
+	it("is enabled for __index within call after nested pop", function()
+		hooks:pop()
+		hooks:pop()
+		hooks:call(function(arg)
+			mt_not_nil.test()
+		end)
+	end)
+
+end)

--- a/spec/formspec_spec.lua
+++ b/spec/formspec_spec.lua
@@ -1,0 +1,116 @@
+-- For self tests package path must be set in a way that makes package loaders search current directory first
+package.path = "./?.lua;../?/init.lua;../?.lua;" --.. package.path
+
+describe("Mineunit formspec", function()
+
+	require("mineunit")
+	mineunit:config_set("silence_global_export_overrides", true)
+	sourcefile("core")
+	sourcefile("server")
+	sourcefile("player")
+	sourcefile("formspec")
+
+	local SX = Player("SX")
+
+	describe("register_on_player_receive_fields", function()
+
+		local test_called = 0
+		local test_formname = "test:formname"
+		function test_callback(player, formname, fields)
+			assert.is_Player(player)
+			assert.not_nil(formname)
+			assert.equals(formname, test_formname)
+			assert.same({a = 1, b = 2}, fields)
+			test_called = test_called + 1
+		end
+
+		before_each(function() test_called = 0 end)
+
+		it("registers callback", function()
+			core.register_on_player_receive_fields(test_callback)
+			assert.in_array(test_callback, core.registered_on_player_receive_fields)
+		end)
+
+		it("executes callback", function()
+			--core.register_on_player_receive_fields(test_callback)
+			assert.equals(0, test_called)
+			mineunit:execute_on_player_receive_fields(SX, test_formname, { a = 1, b = 2 })
+			assert.equals(1, test_called)
+		end)
+
+	end)
+
+	describe("Mineunit:Form", function()
+
+		local test_formspec = ([[formspec_version[3]size[8.000,11.500;]
+			bgcolor[#FFC00F;both;]
+			style_type[*;textcolor=#101010;font_size=*1]
+			style_type[table;textcolor=#101010;font_size=*1;font=mono]
+			style_type[label;textcolor=#101010;font_size=*2]
+			background9[0,0;8.000,11.500;technic_multimeter_bg.png;false;3]
+			image[0.3,0.3;5.75,1;technic_multimeter_logo.png]
+			label[0.6,1.5;Network 1DVYWBCXKX]
+			field[2.733,2.5;2.533,0.8;net;Network ID:;1DVYWBCXKX]
+			image_button[5.367,2.5;2.533,0.8;technic_multimeter_button.png^\[colorize:#10E010:125;
+				rs;Remote start;false;false;technic_multimeter_button_pressed.png^\[colorize:#10E010:125]
+			image_button_exit[0.100,10.600;2.533,0.8;technic_multimeter_button.png;
+				wp;Waypoint;false;false;technic_multimeter_button_pressed.png]
+			image_button[2.733,10.600;2.533,0.8;technic_multimeter_button.png;
+				up;Update;false;false;technic_multimeter_button_pressed.png]
+			image_button_exit[5.367,10.600;2.533,0.8;technic_multimeter_button.png;
+				exit;Exit;false;false;technic_multimeter_button_pressed.png]
+			tableoptions[border=false;background=#4B8E66;highlight=#5CAA77;color=#101010]
+			tablecolumns[indent,width=0.2;text,width=13;text,width=13;text,align=center]
+			table[0.1,3.4;7.800,7.100;items;
+				1,Property,Value,Unit,
+				1,Ref. point,1\,50\,0,coord,
+				1,Activated,yes,active,
+				1,Timeout,1800.0,s,
+				1,Lag,0.30,ms,
+				1,Skip,0,cycles,
+				1,-,-,-,
+				1,Supply,45000,EU,
+				1,Demand,0,EU,
+				1,Battery charge,1000000,EU,
+				1,Battery charge,100,%,
+				1,Battery capacity,1000000,EU,
+				1,-,-,-,
+				1,Nodes,21,count,
+				1,Cables,11,count,
+				1,Generators,9,count,
+				1,Consumers,0,count,
+				1,Batteries,
+				1,count]
+		]]):gsub("[\r\n]\t\t\t*", "")
+
+		it("parses formspecs", function()
+			local form = mineunit:Form("test:formname", test_formspec)
+			assert.is_Form(form)
+
+			assert.equals(form:name(), "test:formname")
+			assert.is_table(form:data())
+
+			local btn_exit = form:one("ex", "image_button_exit")
+			local btn_wp = form:one("w", "image_button_exit")
+
+			assert.equals(btn_exit:name(), "exit")
+			assert.same({5.367,10.600}, btn_exit:pos())
+
+			assert.equals(btn_wp:name(), "wp")
+			assert.same({0.100,10.600}, btn_wp:pos())
+
+			assert.equals(4, #form:all(nil, "image_button"))
+			assert.equals(2, #form:all(nil, "image_button$"))
+			assert.equals(0, #form:all(nil, "^button_exit"))
+
+			assert.equals(2, #form:all("p", nil))
+		end)
+
+		it("provides fields table", function()
+			local form = mineunit:Form("test:formname", test_formspec)
+			assert.is_table(form:fields())
+		end)
+
+	end)
+
+end)

--- a/spec/formspec_spec.lua
+++ b/spec/formspec_spec.lua
@@ -16,7 +16,7 @@ describe("Mineunit formspec", function()
 
 		local test_called = 0
 		local test_formname = "test:formname"
-		function test_callback(player, formname, fields)
+		local function test_callback(player, formname, fields)
 			assert.is_Player(player)
 			assert.not_nil(formname)
 			assert.equals(formname, test_formname)
@@ -109,6 +109,67 @@ describe("Mineunit formspec", function()
 		it("provides fields table", function()
 			local form = mineunit:Form("test:formname", test_formspec)
 			assert.is_table(form:fields())
+		end)
+
+	end)
+
+	describe("player API", function()
+
+		local player = Player("p9", {})
+		before_each(function()
+			mineunit:execute_on_joinplayer(player)
+		end)
+
+		after_each(function()
+			mineunit:execute_on_leaveplayer(player)
+		end)
+
+		it("should show formspecs to the player", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			local form = mineunit:get_player_formspec("p9")
+			assert.is_Form(form)
+			assert.equals("fs1", form:name())
+			assert.equals("field[foo;bar;baz]", form:text())
+		end)
+
+		it("should not hide formspecs when the form name does not match", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			core.close_formspec("p9", "fs2")
+			local form = mineunit:get_player_formspec("p9")
+			assert.is_Form(form)
+			assert.equals("fs1", form:name())
+			assert.equals("field[foo;bar;baz]", form:text())
+		end)
+
+		it("should close formspecs when the form name matches", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			core.close_formspec("p9", "fs1")
+			assert.is_nil(mineunit:get_player_formspec("p9"))
+		end)
+
+		it("should close formspecs when the empty form name is passed", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			core.close_formspec("p9", "")
+			assert.is_nil(mineunit:get_player_formspec("p9"))
+		end)
+
+		it("should call callbacks correctly", function()
+			local count = 0
+			local realfields = { quit = "true" }
+			core.register_on_player_receive_fields(function(playername, formname, fields)
+				if formname == "fs1" then
+					count = 10
+				end
+			end)
+			core.register_on_player_receive_fields(function(playername, formname, fields)
+				assert.same(realfields, fields)
+				count = count + 1
+				return true
+			end)
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			local form = mineunit:get_player_formspec("p9")
+			form:send("p9", realfields)
+			assert.equal(1, count)
 		end)
 
 	end)

--- a/spec/player_spec.lua
+++ b/spec/player_spec.lua
@@ -624,4 +624,67 @@ describe("Core function", function()
 
 	end)
 
+	describe("Formspec system", function()
+
+		mineunit("formspec")
+
+		local player = Player("p9", {})
+		before_each(function()
+			mineunit:execute_on_joinplayer(player)
+		end)
+
+		after_each(function()
+			mineunit:execute_on_leaveplayer(player)
+		end)
+
+		it("should show formspecs to the player", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			local form = mineunit:get_player_formspec("p9")
+			assert.is_Form(form)
+			assert.equals("fs1", form:name())
+			assert.equals("field[foo;bar;baz]", form:text())
+		end)
+
+		it("should not hide formspecs when the form name does not match", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			core.close_formspec("p9", "fs2")
+			local form = mineunit:get_player_formspec("p9")
+			assert.is_Form(form)
+			assert.equals("fs1", form:name())
+			assert.equals("field[foo;bar;baz]", form:text())
+		end)
+
+		it("should close formspecs when the form name matches", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			core.close_formspec("p9", "fs1")
+			assert.is_nil(mineunit:get_player_formspec("p9"))
+		end)
+
+		it("should close formspecs when the empty form name is passed", function()
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			core.close_formspec("p9", "")
+			assert.is_nil(mineunit:get_player_formspec("p9"))
+		end)
+
+		it("should call callbacks correctly", function()
+			local count = 0
+			local realfields = { quit = "true" }
+			core.register_on_player_receive_fields(function(playername, formname, fields)
+				if formname == "fs1" then
+					count = 10
+				end
+			end)
+			core.register_on_player_receive_fields(function(playername, formname, fields)
+				assert.same(realfields, fields)
+				count = 1
+				return true
+			end)
+			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
+			local form = mineunit:get_player_formspec("p9")
+			form:send("p9", realfields)
+			assert.equal(1, count)
+		end)
+
+	end)
+
 end)

--- a/spec/player_spec.lua
+++ b/spec/player_spec.lua
@@ -582,6 +582,10 @@ describe("Core function", function()
 
 		it("returns inventory", function()
 			local player = Player("Sam")
+			mineunit:execute_on_joinplayer(player)
+			finally(function()
+				mineunit:execute_on_leaveplayer(player)
+			end)
 			player:set_wielded_item("test")
 			local inv = core.get_inventory({ type = "player", name = "Sam" })
 			assert.is_InvRef(inv)
@@ -620,69 +624,6 @@ describe("Core function", function()
 		it("handles noexistent inventory", function()
 			local inv = core.remove_detached_inventory("doesntexist")
 			assert.is_false(inv)
-		end)
-
-	end)
-
-	describe("Formspec system", function()
-
-		mineunit("formspec")
-
-		local player = Player("p9", {})
-		before_each(function()
-			mineunit:execute_on_joinplayer(player)
-		end)
-
-		after_each(function()
-			mineunit:execute_on_leaveplayer(player)
-		end)
-
-		it("should show formspecs to the player", function()
-			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
-			local form = mineunit:get_player_formspec("p9")
-			assert.is_Form(form)
-			assert.equals("fs1", form:name())
-			assert.equals("field[foo;bar;baz]", form:text())
-		end)
-
-		it("should not hide formspecs when the form name does not match", function()
-			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
-			core.close_formspec("p9", "fs2")
-			local form = mineunit:get_player_formspec("p9")
-			assert.is_Form(form)
-			assert.equals("fs1", form:name())
-			assert.equals("field[foo;bar;baz]", form:text())
-		end)
-
-		it("should close formspecs when the form name matches", function()
-			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
-			core.close_formspec("p9", "fs1")
-			assert.is_nil(mineunit:get_player_formspec("p9"))
-		end)
-
-		it("should close formspecs when the empty form name is passed", function()
-			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
-			core.close_formspec("p9", "")
-			assert.is_nil(mineunit:get_player_formspec("p9"))
-		end)
-
-		it("should call callbacks correctly", function()
-			local count = 0
-			local realfields = { quit = "true" }
-			core.register_on_player_receive_fields(function(playername, formname, fields)
-				if formname == "fs1" then
-					count = 10
-				end
-			end)
-			core.register_on_player_receive_fields(function(playername, formname, fields)
-				assert.same(realfields, fields)
-				count = 1
-				return true
-			end)
-			core.show_formspec("p9", "fs1", "field[foo;bar;baz]")
-			local form = mineunit:get_player_formspec("p9")
-			form:send("p9", realfields)
-			assert.equal(1, count)
 		end)
 
 	end)

--- a/voxelmanip.lua
+++ b/voxelmanip.lua
@@ -8,6 +8,7 @@
 -- 3. If there are holes in the VoxelManip data due to multiple calls to
 --    read_from_map(), the placeholder data in these holes cannot be changed by
 --    set_data() etc. This is very unlikely to be a problem.
+local hooks = mineunit.debughooks
 
 mineunit("core")
 
@@ -47,6 +48,7 @@ function VoxelManip:get_emerged_area()
 end
 
 function VoxelManip:read_from_map(p1, p2)
+	hooks:pop()
 	local bpmin, bpmax = vector.sort(pos2blockpos(p1), pos2blockpos(p2))
 
 	local minp = block_min_pos(bpmin)
@@ -75,10 +77,12 @@ function VoxelManip:read_from_map(p1, p2)
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return self:get_emerged_area()
 end
 
 function VoxelManip:write_to_map()
+	hooks:pop()
 	local vm_nodes, world_nodes = self._nodes, world.nodes
 	local emin, emax = self._emin, self._emax
 	local p = vector.new(emin)
@@ -98,6 +102,7 @@ function VoxelManip:write_to_map()
 		p.y = emin.y
 		p.z = p.z + 1
 	end
+	hooks:push()
 end
 
 function VoxelManip:update_liquids()
@@ -112,6 +117,7 @@ function VoxelManip:get_node_at(pos)
 end
 
 function VoxelManip:set_node_at(pos, node)
+	hooks:pop()
 	local nodedef = core.registered_nodes[node.name]
 	if nodedef == nil then
 		error("Invalid node name '" .. tostring(node.name) .. "'")
@@ -121,9 +127,11 @@ function VoxelManip:set_node_at(pos, node)
 		param1 = node.param1 or 0,
 		param2 = node.param2 or 0,
 	}
+	hooks:push()
 end
 
 function VoxelManip:get_data(buf)
+	hooks:pop()
 	buf = buf or {}
 
 	local vm_nodes = self._nodes
@@ -144,10 +152,12 @@ function VoxelManip:get_data(buf)
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return buf
 end
 
 function VoxelManip:get_light_data()
+	hooks:pop()
 	local buf = {}
 
 	local vm_nodes = self._nodes
@@ -168,10 +178,12 @@ function VoxelManip:get_light_data()
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return buf
 end
 
 function VoxelManip:get_param2_data(buf)
+	hooks:pop()
 	buf = buf or {}
 
 	local vm_nodes = self._nodes
@@ -192,10 +204,12 @@ function VoxelManip:get_param2_data(buf)
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return buf
 end
 
 function VoxelManip:set_data(buf)
+	hooks:pop()
 	local vm_nodes = self._nodes
 	local emin, emax = self._emin, self._emax
 	local i = 1
@@ -220,10 +234,12 @@ function VoxelManip:set_data(buf)
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return buf
 end
 
 function VoxelManip:set_light_data(buf)
+	hooks:pop()
 	local vm_nodes = self._nodes
 	local emin, emax = self._emin, self._emax
 	local i = 1
@@ -248,10 +264,12 @@ function VoxelManip:set_light_data(buf)
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return buf
 end
 
 function VoxelManip:set_param2_data(buf)
+	hooks:pop()
 	local vm_nodes = self._nodes
 	local emin, emax = self._emin, self._emax
 	local i = 1
@@ -276,6 +294,7 @@ function VoxelManip:set_param2_data(buf)
 		p.z = p.z + 1
 	end
 
+	hooks:push()
 	return buf
 end
 

--- a/world.lua
+++ b/world.lua
@@ -1,3 +1,5 @@
+local hooks = mineunit.debughooks
+
 local world = {}
 local world_default_node
 
@@ -26,7 +28,7 @@ world.clear()
 -- Helper to execute callbacks
 local function call(fn, ...)
 	if type(fn) == "function" then
-		return fn(...)
+		return hooks:get(fn, ...)
 	end
 end
 
@@ -51,9 +53,12 @@ end
 
 -- FIXME: Should also execute other related callbacks
 function world.on_dig(pos, node, digger)
+	hooks:pop()
 	node = node or minetest.get_node(pos)
 	local nodedef = minetest.registered_nodes[node.name]
-	return nodedef and call(nodedef.on_dig, pos, node, digger) and true or false
+	local result = nodedef and call(nodedef.on_dig, pos, node, digger) and true or false
+	hooks:push()
+	return result
 end
 
 function world.clear_meta(pos)
@@ -83,6 +88,7 @@ end
 
 -- set_node sets world node without place/dig callbacks
 function world.set_node(pos, node)
+	hooks:pop()
 	node = create_node(node)
 	assert(type(node.name) == "string", "Invalid node name, expected string but got " .. tostring(node.name))
 	local hash = minetest.hash_node_position(pos)
@@ -100,20 +106,24 @@ function world.set_node(pos, node)
 	if nodedef then
 		call(nodedef.on_construct, pos)
 	end
+	hooks:push()
 end
 
 -- swap_node sets world node without any callbacks
 function world.swap_node(pos, node)
+	hooks:pop()
 	local hash = minetest.hash_node_position(pos)
 	node = create_node(node, world.nodes[hash])
 	assert(type(node.name) == "string", "Invalid node name, expected string but got " .. tostring(node.name))
 	world.nodes[hash] = node
+	hooks:push()
 end
 
 -- Called after constructing node when node was placed using
 -- minetest.item_place_node / minetest.place_node.
 -- If return true no item is taken from itemstack.
 function world.place_node(pos, node, placer, itemstack, pointed_thing)
+	hooks:pop()
 	node = create_node(node)
 	world.set_node(pos, node)
 	local nodedef = core.registered_nodes[node.name]
@@ -123,6 +133,7 @@ function world.place_node(pos, node, placer, itemstack, pointed_thing)
 		pointed_thing = pointed_thing or get_pointed_thing(pos)
 		call(nodedef.after_place_node, pos, placer, itemstack, pointed_thing)
 	end
+	hooks:push()
 end
 
 local function has_meta(pos)
@@ -163,6 +174,7 @@ end
 
 -- FIXME: Does not handle node groups at all, groups are completely ignored
 function world.find_nodes_in_area(p1, p2, nodenames, grouped)
+	hooks:pop()
 	assert.is_table(p1, "Invalid p1, table expected")
 	assert.is_table(p2, "Invalid p2, table expected")
 	local sx, sy, sz = math.min(p1.x, p2.x), math.min(p1.y, p2.y), math.min(p1.z, p2.z)
@@ -189,6 +201,7 @@ function world.find_nodes_in_area(p1, p2, nodenames, grouped)
 				end
 			end
 		end
+		hooks:push()
 		return results
 	else
 		local positions = {}
@@ -200,11 +213,13 @@ function world.find_nodes_in_area(p1, p2, nodenames, grouped)
 				end
 			end
 		end
+		hooks:push()
 		return positions, counts
 	end
 end
 
 function world.find_nodes_with_meta(p1, p2)
+	hooks:pop()
 	assert.is_table(p1, "Invalid p1, table expected")
 	assert.is_table(p2, "Invalid p2, table expected")
 	local sx, sy, sz = math.min(p1.x, p2.x), math.min(p1.y, p2.y), math.min(p1.z, p2.z)
@@ -220,6 +235,7 @@ function world.find_nodes_with_meta(p1, p2)
 			end
 		end
 	end
+	hooks:push()
 	return results
 end
 
@@ -251,6 +267,7 @@ local function get_layout_area(def, offset)
 end
 
 function world.add_layout(layout, offset)
+	hooks:pop()
 	for _, node in ipairs(layout) do
 		local p1, p2 = get_layout_area(node[1], offset)
 		for x = p1.x, p2.x do
@@ -261,6 +278,7 @@ function world.add_layout(layout, offset)
 			end
 		end
 	end
+	hooks:push()
 end
 
 _G.world = world


### PR DESCRIPTION
### What's included

* #105 (changes now included in this PR)
   * Formspec testing added.
   * Closes #53 
* #117 (changes now included in this PR)
   * Changed:
      * Better compatibility with different engine versions.
      * Coverage / debug dynamic hooks for better performance.
      * Closes #7
   * Somewhat related issues:
      * #4 
      * #38 
      * #64 
* Other
   * Added some missing engine API functions.
   * Added some missing Player methods.
   * Fixed some broken Player methods.
   * Fixed some auth handler issues.
   * Formatters `%x` (hex dump) and `%@` (source file+line).
   * Better documentation coverage.

### Basic smoke tests

<details><summary><i>Engine version <b>mineunit</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (mineunit)     | 240     | 0      | 0     | 1       | 0.937749 |
| Mineunit demo spec (mineunit)      | 8       | 0      | 0     | 1       | 0.027467 |
| advtrains/serialize_lib (mineunit) | 5       | 0      | 0     | 0       | 0.013357 |
| beerchat (mineunit)                | 213     | 0      | 0     | 0       | 0.597844 |
| geoip (mineunit)                   | 11      | 0      | 0     | 2       | 0.035685 |
| machine_parts (mineunit)           | 5       | 0      | 0     | 0       | 0.028449 |
| mesecons (mineunit)                | 20      | 0      | 0     | 0       | 1.051214 |
| mesecons_mvps (mineunit)           | 19      | 0      | 0     | 3       | 0.217269 |
| mesecons_fpga (mineunit)           | 28      | 0      | 0     | 0       | 1.335504 |
| mesecons_luacontroller (mineunit)  | 12      | 0      | 0     | 0       | 0.295131 |
| metatool (mineunit)                | 21      | 0      | 0     | 0       | 0.033361 |
| containertool (mineunit)           | 10      | 0      | 0     | 0       | 0.024115 |
| sharetool (mineunit)               | 15      | 0      | 0     | 0       | 0.025776 |
| tubetool (mineunit)                | 33      | 0      | 0     | 0       | 0.025538 |
| modular_computers (mineunit)       | 5       | 0      | 0     | 0       | 0.023904 |
| spectator_mode (mineunit)          | 21      | 0      | 0     | 0       | 0.025663 |
| qos (mineunit)                     | 31      | 0      | 0     | 3       | 0.066014 |

</details>

<details><summary><i>Engine version <b>5.4.1</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.4.1)        | 240     | 0      | 0     | 1       | 0.952412 |
| Mineunit demo spec (5.4.1)         | 8       | 0      | 0     | 1       | 0.027762 |
| advtrains/serialize_lib (5.4.1)    | 5       | 0      | 0     | 0       | 0.013621 |
| beerchat (5.4.1)                   | 213     | 0      | 0     | 0       | 0.599928 |
| geoip (5.4.1)                      | 11      | 0      | 0     | 2       | 0.034699 |
| machine_parts (5.4.1)              | 5       | 0      | 0     | 0       | 0.028678 |
| mesecons (5.4.1)                   | 20      | 0      | 0     | 0       | 1.055474 |
| mesecons_mvps (5.4.1)              | 19      | 0      | 0     | 3       | 0.21771  |
| mesecons_fpga (5.4.1)              | 28      | 0      | 0     | 0       | 1.328407 |
| mesecons_luacontroller (5.4.1)     | 12      | 0      | 0     | 0       | 0.286374 |
| metatool (5.4.1)                   | 21      | 0      | 0     | 0       | 0.03273  |
| containertool (5.4.1)              | 10      | 0      | 0     | 0       | 0.023948 |
| sharetool (5.4.1)                  | 15      | 0      | 0     | 0       | 0.025084 |
| tubetool (5.4.1)                   | 33      | 0      | 0     | 0       | 0.024725 |
| modular_computers (5.4.1)          | 5       | 0      | 0     | 0       | 0.02295  |
| spectator_mode (5.4.1)             | 21      | 0      | 0     | 0       | 0.025606 |
| qos (5.4.1)                        | 31      | 0      | 0     | 3       | 0.064727 |
| technic/technic (5.4.1)            | 243     | 0      | 0     | 4       | 4.971671 |
| technic/technic_cnc (5.4.1)        | 31      | 0      | 0     | 0       | 0.346433 |
| technic/technic_chests (5.4.1)     | 5       | 0      | 0     | 0       | 0.022337 |

</details>

<details><summary><i>Engine version <b>5.5.1</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.5.1)        | 240     | 0      | 0     | 1       | 0.968286 |
| Mineunit demo spec (5.5.1)         | 8       | 0      | 0     | 1       | 0.028944 |
| advtrains/serialize_lib (5.5.1)    | 5       | 0      | 0     | 0       | 0.014336 |
| beerchat (5.5.1)                   | 213     | 0      | 0     | 0       | 0.614549 |
| geoip (5.5.1)                      | 11      | 0      | 0     | 2       | 0.038796 |
| machine_parts (5.5.1)              | 5       | 0      | 0     | 0       | 0.033673 |
| mesecons (5.5.1)                   | 20      | 0      | 0     | 0       | 1.058777 |
| mesecons_mvps (5.5.1)              | 19      | 0      | 0     | 3       | 0.228123 |
| mesecons_fpga (5.5.1)              | 28      | 0      | 0     | 0       | 1.340673 |
| mesecons_luacontroller (5.5.1)     | 12      | 0      | 0     | 0       | 0.297793 |
| metatool (5.5.1)                   | 21      | 0      | 0     | 0       | 0.035389 |
| containertool (5.5.1)              | 10      | 0      | 0     | 0       | 0.023663 |
| sharetool (5.5.1)                  | 15      | 0      | 0     | 0       | 0.029325 |
| tubetool (5.5.1)                   | 33      | 0      | 0     | 0       | 0.02686  |
| modular_computers (5.5.1)          | 5       | 0      | 0     | 0       | 0.027483 |
| spectator_mode (5.5.1)             | 21      | 0      | 0     | 0       | 0.028083 |
| qos (5.5.1)                        | 31      | 0      | 0     | 3       | 0.071149 |
| technic/technic (5.5.1)            | 238     | 5      | 0     | 4       | 5.230286 |
| technic/technic_cnc (5.5.1)        | 31      | 0      | 0     | 0       | 0.359629 |
| technic/technic_chests (5.5.1)     | 5       | 0      | 0     | 0       | 0.025426 |

</details>

<details><summary><i>Engine version <b>5.6.1</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.6.1)        | 240     | 0      | 0     | 1       | 0.967268 |
| Mineunit demo spec (5.6.1)         | 8       | 0      | 0     | 1       | 0.031026 |
| advtrains/serialize_lib (5.6.1)    | 5       | 0      | 0     | 0       | 0.014312 |
| beerchat (5.6.1)                   | 213     | 0      | 0     | 0       | 0.66485  |
| geoip (5.6.1)                      | 11      | 0      | 0     | 2       | 0.045181 |
| machine_parts (5.6.1)              | 5       | 0      | 0     | 0       | 0.042175 |
| mesecons (5.6.1)                   | 20      | 0      | 0     | 0       | 1.077436 |
| mesecons_mvps (5.6.1)              | 19      | 0      | 0     | 3       | 0.231959 |
| mesecons_fpga (5.6.1)              | 28      | 0      | 0     | 0       | 1.361115 |
| mesecons_luacontroller (5.6.1)     | 12      | 0      | 0     | 0       | 0.327877 |
| metatool (5.6.1)                   | 21      | 0      | 0     | 0       | 0.047551 |
| containertool (5.6.1)              | 10      | 0      | 0     | 0       | 0.027431 |
| sharetool (5.6.1)                  | 15      | 0      | 0     | 0       | 0.031719 |
| tubetool (5.6.1)                   | 33      | 0      | 0     | 0       | 0.032472 |
| modular_computers (5.6.1)          | 5       | 0      | 0     | 0       | 0.02866  |
| spectator_mode (5.6.1)             | 21      | 0      | 0     | 0       | 0.029531 |
| qos (5.6.1)                        | 31      | 0      | 0     | 3       | 0.087808 |
| technic/technic (5.6.1)            | 243     | 0      | 0     | 4       | 5.041934 |
| technic/technic_cnc (5.6.1)        | 31      | 0      | 0     | 0       | 0.396085 |
| technic/technic_chests (5.6.1)     | 5       | 0      | 0     | 0       | 0.026951 |

</details>

<details><summary><i>Engine version <b>5.7.0</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.7.0)        | 240     | 0      | 0     | 1       | 0.990996 |
| Mineunit demo spec (5.7.0)         | 8       | 0      | 0     | 1       | 0.031256 |
| advtrains/serialize_lib (5.7.0)    | 5       | 0      | 0     | 0       | 0.013007 |
| beerchat (5.7.0)                   | 213     | 0      | 0     | 0       | 0.666422 |
| geoip (5.7.0)                      | 11      | 0      | 0     | 2       | 0.046481 |
| machine_parts (5.7.0)              | 5       | 0      | 0     | 0       | 0.044257 |
| mesecons (5.7.0)                   | 20      | 0      | 0     | 0       | 1.073755 |
| mesecons_mvps (5.7.0)              | 19      | 0      | 0     | 3       | 0.233617 |
| mesecons_fpga (5.7.0)              | 28      | 0      | 0     | 0       | 1.345645 |
| mesecons_luacontroller (5.7.0)     | 12      | 0      | 0     | 0       | 0.32379  |
| metatool (5.7.0)                   | 21      | 0      | 0     | 0       | 0.048809 |
| containertool (5.7.0)              | 10      | 0      | 0     | 0       | 0.02818  |
| sharetool (5.7.0)                  | 15      | 0      | 0     | 0       | 0.032394 |
| tubetool (5.7.0)                   | 33      | 0      | 0     | 0       | 0.032084 |
| modular_computers (5.7.0)          | 5       | 0      | 0     | 0       | 0.028629 |
| spectator_mode (5.7.0)             | 21      | 0      | 0     | 0       | 0.030141 |
| qos (5.7.0)                        | 31      | 0      | 0     | 3       | 0.088773 |
| technic/technic (5.7.0)            | 243     | 0      | 0     | 4       | 5.110988 |
| technic/technic_cnc (5.7.0)        | 31      | 0      | 0     | 0       | 0.384903 |
| technic/technic_chests (5.7.0)     | 5       | 0      | 0     | 0       | 0.03042  |

</details>

<details><summary><i>Engine version <b>5.8.0</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.8.0)        | 240     | 0      | 0     | 1       | 0.981457 |
| Mineunit demo spec (5.8.0)         | 8       | 0      | 0     | 1       | 0.03159  |
| advtrains/serialize_lib (5.8.0)    | 5       | 0      | 0     | 0       | 0.01332  |
| beerchat (5.8.0)                   | 213     | 0      | 0     | 0       | 0.655738 |
| geoip (5.8.0)                      | 11      | 0      | 0     | 2       | 0.046667 |
| machine_parts (5.8.0)              | 5       | 0      | 0     | 0       | 0.044216 |
| mesecons (5.8.0)                   | 20      | 0      | 0     | 0       | 1.074137 |
| mesecons_mvps (5.8.0)              | 19      | 0      | 0     | 3       | 0.228595 |
| mesecons_fpga (5.8.0)              | 28      | 0      | 0     | 0       | 1.322005 |
| mesecons_luacontroller (5.8.0)     | 12      | 0      | 0     | 0       | 0.320694 |
| metatool (5.8.0)                   | 21      | 0      | 0     | 0       | 0.048638 |
| containertool (5.8.0)              | 10      | 0      | 0     | 0       | 0.029238 |
| sharetool (5.8.0)                  | 15      | 0      | 0     | 0       | 0.030963 |
| tubetool (5.8.0)                   | 33      | 0      | 0     | 0       | 0.031348 |
| modular_computers (5.8.0)          | 5       | 0      | 0     | 0       | 0.027861 |
| spectator_mode (5.8.0)             | 21      | 0      | 0     | 0       | 0.030086 |
| qos (5.8.0)                        | 31      | 0      | 0     | 3       | 0.089292 |
| technic/technic (5.8.0)            | 243     | 0      | 0     | 4       | 5.033283 |
| technic/technic_cnc (5.8.0)        | 31      | 0      | 0     | 0       | 0.378369 |
| technic/technic_chests (5.8.0)     | 5       | 0      | 0     | 0       | 0.026972 |

</details>

<details><summary><i>Engine version <b>5.9.1</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.9.1)        | 240     | 0      | 0     | 1       | 0.977885 |
| Mineunit demo spec (5.9.1)         | 8       | 0      | 0     | 1       | 0.033097 |
| advtrains/serialize_lib (5.9.1)    | 5       | 0      | 0     | 0       | 0.013456 |
| beerchat (5.9.1)                   | 213     | 0      | 0     | 0       | 0.667264 |
| geoip (5.9.1)                      | 11      | 0      | 0     | 2       | 0.046602 |
| machine_parts (5.9.1)              | 5       | 0      | 0     | 0       | 0.047523 |
| mesecons (5.9.1)                   | 20      | 0      | 0     | 0       | 1.076552 |
| mesecons_mvps (5.9.1)              | 19      | 0      | 0     | 3       | 0.231243 |
| mesecons_fpga (5.9.1)              | 28      | 0      | 0     | 0       | 1.326898 |
| mesecons_luacontroller (5.9.1)     | 12      | 0      | 0     | 0       | 0.32138  |
| metatool (5.9.1)                   | 21      | 0      | 0     | 0       | 0.047711 |
| containertool (5.9.1)              | 10      | 0      | 0     | 0       | 0.029379 |
| sharetool (5.9.1)                  | 15      | 0      | 0     | 0       | 0.032391 |
| tubetool (5.9.1)                   | 33      | 0      | 0     | 0       | 0.031961 |
| modular_computers (5.9.1)          | 5       | 0      | 0     | 0       | 0.028015 |
| spectator_mode (5.9.1)             | 20      | 0      | 1     | 0       | 0.030017 |
| qos (5.9.1)                        | 31      | 0      | 0     | 3       | 0.090335 |
| technic/technic (5.9.1)            | 243     | 0      | 0     | 4       | 4.999832 |
| technic/technic_cnc (5.9.1)        | 31      | 0      | 0     | 0       | 0.381317 |
| technic/technic_chests (5.9.1)     | 5       | 0      | 0     | 0       | 0.027015 |

</details>

<details><summary><i>Engine version <b>5.10.0</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.10.0)       | 240     | 0      | 0     | 1       | 0.99579  |
| Mineunit demo spec (5.10.0)        | 8       | 0      | 0     | 1       | 0.034401 |
| advtrains/serialize_lib (5.10.0)   | 5       | 0      | 0     | 0       | 0.014612 |
| beerchat (5.10.0)                  | 213     | 0      | 0     | 0       | 0.678854 |
| geoip (5.10.0)                     | 11      | 0      | 0     | 2       | 0.047067 |
| machine_parts (5.10.0)             | 5       | 0      | 0     | 0       | 0.048696 |
| mesecons (5.10.0)                  | 20      | 0      | 0     | 0       | 1.073105 |
| mesecons_mvps (5.10.0)             | 19      | 0      | 0     | 3       | 0.238385 |
| mesecons_fpga (5.10.0)             | 28      | 0      | 0     | 0       | 1.35958  |
| mesecons_luacontroller (5.10.0)    | 12      | 0      | 0     | 0       | 0.330561 |
| metatool (5.10.0)                  | 21      | 0      | 0     | 0       | 0.0496   |
| containertool (5.10.0)             | 10      | 0      | 0     | 0       | 0.028866 |
| sharetool (5.10.0)                 | 15      | 0      | 0     | 0       | 0.032819 |
| tubetool (5.10.0)                  | 33      | 0      | 0     | 0       | 0.032828 |
| modular_computers (5.10.0)         | 5       | 0      | 0     | 0       | 0.029199 |
| spectator_mode (5.10.0)            | 20      | 0      | 1     | 0       | 0.031993 |
| qos (5.10.0)                       | 31      | 0      | 0     | 3       | 0.095578 |
| technic/technic (5.10.0)           | 243     | 0      | 0     | 4       | 5.05465  |
| technic/technic_cnc (5.10.0)       | 31      | 0      | 0     | 0       | 0.382581 |
| technic/technic_chests (5.10.0)    | 5       | 0      | 0     | 0       | 0.026375 |

</details>

<details><summary><i>Engine version <b>5.11.0</b></i></summary>

| Tested mod                         | success | failed | error | pending | seconds  |
| -- | -- | -- | -- | -- | -- |
| Mineunit self tests (5.11.0)       | 240     | 0      | 0     | 1       | 0.984401 |
| Mineunit demo spec (5.11.0)        | 8       | 0      | 0     | 1       | 0.032661 |
| advtrains/serialize_lib (5.11.0)   | 5       | 0      | 0     | 0       | 0.013695 |
| beerchat (5.11.0)                  | 213     | 0      | 0     | 0       | 0.668958 |
| geoip (5.11.0)                     | 11      | 0      | 0     | 2       | 0.046821 |
| machine_parts (5.11.0)             | 5       | 0      | 0     | 0       | 0.047467 |
| mesecons (5.11.0)                  | 20      | 0      | 0     | 0       | 1.080528 |
| mesecons_mvps (5.11.0)             | 19      | 0      | 0     | 3       | 0.236161 |
| mesecons_fpga (5.11.0)             | 28      | 0      | 0     | 0       | 1.350497 |
| mesecons_luacontroller (5.11.0)    | 12      | 0      | 0     | 0       | 0.326509 |
| metatool (5.11.0)                  | 21      | 0      | 0     | 0       | 0.04804  |
| containertool (5.11.0)             | 10      | 0      | 0     | 0       | 0.030598 |
| sharetool (5.11.0)                 | 15      | 0      | 0     | 0       | 0.0332   |
| tubetool (5.11.0)                  | 33      | 0      | 0     | 0       | 0.032649 |
| modular_computers (5.11.0)         | 5       | 0      | 0     | 0       | 0.02825  |
| spectator_mode (5.11.0)            | 20      | 0      | 1     | 0       | 0.031346 |
| qos (5.11.0)                       | 31      | 0      | 0     | 3       | 0.094525 |
| technic/technic (5.11.0)           | 243     | 0      | 0     | 4       | 5.043689 |
| technic/technic_cnc (5.11.0)       | 31      | 0      | 0     | 0       | 0.378351 |
| technic/technic_chests (5.11.0)    | 5       | 0      | 0     | 0       | 0.027034 |

</details>